### PR TITLE
Disallow "else if" rule

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -6,6 +6,11 @@ The Doctrine project follows a coding standard based on
 additions and modifications.
 When contributing to the Doctrine project, the following rules have to be met in order to fulfill this standard.
 
+Control Structures
+------------------
+
+- There is no `else if`, you MUST use `elseif` instead.
+
 Formatting
 ----------
 

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -5,6 +5,11 @@
     <!-- Import PSR-2 coding standard (base) -->
     <rule ref="PSR2"/>
 
+    <!-- Disallow else if in favour elseif -->
+    <rule ref="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed">
+        <type>error</type>
+    </rule>
+    
     <!-- Align corresponding assignment statement tokens -->
     <rule ref="Generic.Formatting.MultipleStatementAlignment">
         <properties>


### PR DESCRIPTION
Throughout the Doctrine repositories there has been discussed that there is no `else if` and this is exactly what this PR enforces. PSR-2 already covers this but only throws a warning instead of an error. Either it doesn't matter whether `else if` of `elseif` is used and we don't need a rule at all, or we enforce an error here.
