### PR TITLE
[RFC] Reference global functions and constants via `use`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.1",
         "squizlabs/php_codesniffer": "^3.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.2",
-        "slevomat/coding-standard": "^4.2.1"
+        "slevomat/coding-standard": "^4.3.0"
     },
     "extra": {
         "branch-alias": {

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -108,10 +108,14 @@
     <!-- Forbid using absolute class name references (except global ones) -->
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
         <properties>
+            <property name="allowFallbackGlobalConstants" type="boolean" value="false"/>
+            <property name="allowFallbackGlobalFunctions" type="boolean" value="false"/>
             <property name="allowFullyQualifiedGlobalClasses" type="boolean" value="true"/>
-            <property name="allowFullyQualifiedGlobalFunctions" type="boolean" value="true"/>
-            <property name="allowFullyQualifiedGlobalConstants" type="boolean" value="true"/>
+            <property name="allowFullyQualifiedGlobalConstants" type="boolean" value="false"/>
+            <property name="allowFullyQualifiedGlobalFunctions" type="boolean" value="false"/>
             <property name="allowFullyQualifiedNameForCollidingClasses" type="boolean" value="true"/>
+            <property name="allowFullyQualifiedNameForCollidingConstants" type="boolean" value="true"/>
+            <property name="allowFullyQualifiedNameForCollidingFunctions" type="boolean" value="true"/>
         </properties>
     </rule>
     <!-- Forbid unused use statements -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -4,14 +4,14 @@ PHP CODE SNIFFER REPORT SUMMARY
 FILE                                                  ERRORS  WARNINGS
 ----------------------------------------------------------------------
 tests/input/concatenation_spacing.php                 24      0
-tests/input/example-class.php                         13      0
+tests/input/example-class.php                         14      0
 tests/input/not_spacing.php                           7       0
 tests/input/return_type_on_closures.php               21      0
 tests/input/return_type_on_methods.php                17      0
 ----------------------------------------------------------------------
-A TOTAL OF 82 ERRORS AND 0 WARNINGS WERE FOUND IN 5 FILES
+A TOTAL OF 83 ERRORS AND 0 WARNINGS WERE FOUND IN 5 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 72 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 73 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/example-class.php
+++ b/tests/fixed/example-class.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Example;
 
 use Doctrine\Sniffs\Spacing\ControlStructureSniff;
+use function assert;
 use function strlen;
 use function substr;
 


### PR DESCRIPTION
### Motivation
As of PHP 5.3, function invocation in namespaced code is two-step operation. First, function is looked up in current namespace, if not found the _fallback_ mode looks up the function in global scope. This effectively means that global function calls from namespaced code are slower and additionally kill further optimizations and/or inlining into special opcodes, done for [some core functions](https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3048#issuecomment-328810072). Granted, OPcache likely [optimizes the two-step function lookups](https://github.com/php/php-src/blob/php-7.2.0/ext/opcache/Optimizer/optimize_func_calls.c#L150) and [further optimizes some other functions](https://github.com/php/php-src/blob/php-7.2.0/ext/opcache/Optimizer/pass1_5.c#L407), but won't make them compile into specific opcode, and is also usually disabled in CLI.

### Solution
There are two ways how to avoid _fallback_ lookups:
1) prepend function calls by backslash (`\strlen()`),
2) add functions into imports (`use function strlen`).

Although approach 1) is more compact at first sight, it clutters code a lot with backslashes making it harder to read. Imports on the other hand don't - the code itself stays as simple as before and untouched. PHP optimizations do not differentiate between 1) and 2) or even import aliases so either is okay. With proper IDE support both are pretty easy to handle without much hassle.

### Further reading
* https://veewee.github.io/blog/optimizing-php-performance-by-fq-function-calls/
* http://php.net/manual/en/language.namespaces.faq.php#language.namespaces.faq.shortname2
* https://github.com/Roave/FunctionFQNReplacer#rationale
* https://twitter.com/Ocramius/status/811504929357660160
* https://3v4l.org/YiCjS/vld#output

### IDE support
PhpStorm supports autoimports of global functions and constants for a while already: https://blog.jetbrains.com/phpstorm/2017/01/phpstorm-2017-1-eap-171-2455/
![obrazek](https://user-images.githubusercontent.com/144181/34699567-585118f4-f4de-11e7-8add-616c2ba37641.png)

Based on discussion and implementation for doctrine/doctrine2#6807.
ORM example (unsorted): https://github.com/Majkl578/doctrine2/commit/78fc09c56e2ad43deceb85a8267a14adc552dfd5


I'd like to hear some feedback on this topic and proposed solution. Thanks.