### PR TITLE
Propose semantic versioning of the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ You might also do automatic fixes using `phpcbf`:
 $ phpcbf --standard=Doctrine /path/to/some/file/to/sniff.php
 ```
 
+Versioning
+----------
+
+This library follows semantic versioning, and additions to the code ruleset
+are only performed in major releases.
+
 Testing
 -------
 


### PR DESCRIPTION
Since we released `2.0.0` of this library, we started adding more rules in `2.1.0`.
This led to consumers of the library to lock onto `~2.1.0` rather than `^2.1.0`.

Effectively, this means that our consumers (library authors) consider our minor
releases to be major releases (and rightfully so!).

This patch suggests to use major versions for any addition to the ruleset that may
lead to code change requirements downstream in consumers, and makes this package
"less special" among the dependencies of any project relying on it.