### PR TITLE
Add Null Coalesce Operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ exceptions/differences/extensions (:white_check_mark: are the implemented sniffs
 - :white_check_mark: Omit phpDoc for parameters/returns with native types, unless adding description
 - :white_check_mark: Don't use `@author`, `@since` and similar annotations that duplicate Git information
 - :white_check_mark: Assignment in condition is not allowed
+- :white_check_mark: Use Null Coalesce Operator `$foo = $bar ?? $baz`
 
 For full reference of enforcements, go through `lib/Doctrine/ruleset.xml` where each sniff is briefly described.
 

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -95,6 +95,8 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEqualOperators"/>
     <!-- Require language constructs without parentheses -->
     <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses"/>
+    <!-- Require usage of null coalesce operator when possible -->
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
     <!-- Forbid useless unreachable catch blocks -->
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
     <!-- Require using Throwable instead of Exception -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -6,13 +6,14 @@ FILE                                                  ERRORS  WARNINGS
 tests/input/concatenation_spacing.php                 24      0
 tests/input/example-class.php                         19      0
 tests/input/not_spacing.php                           7       0
+tests/input/null_coalesce_operator.php                3       0
 tests/input/return_type_on_closures.php               21      0
 tests/input/return_type_on_methods.php                17      0
 tests/input/test-case.php                             6       0
 ----------------------------------------------------------------------
-A TOTAL OF 94 ERRORS AND 0 WARNINGS WERE FOUND IN 6 FILES
+A TOTAL OF 97 ERRORS AND 0 WARNINGS WERE FOUND IN 7 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 83 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 86 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/null_coalesce_operator.php
+++ b/tests/fixed/null_coalesce_operator.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+$foo = $_GET['foo'] ?? 'foo';
+
+$bar = $bar ?? 'bar';
+
+$bar = $bar['baz'] ?? 'baz';
+
+if (isset($foo)) {
+    $bar = $foo;
+} else {
+    $bar = 'foo';
+}
+
+$fooBar = isset($foo, $bar) ? 'foo' : 'bar';
+
+$baz = ! isset($foo) ? 'foo' : 'baz';

--- a/tests/input/null_coalesce_operator.php
+++ b/tests/input/null_coalesce_operator.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+$foo = isset($_GET['foo']) ? $_GET['foo'] : 'foo';
+
+$bar = isset($bar) ? $bar : 'bar';
+
+$bar = isset($bar['baz']) ? $bar['baz'] : 'baz';
+
+if (isset($foo)) {
+    $bar = $foo;
+} else {
+    $bar = 'foo';
+}
+
+$fooBar = isset($foo, $bar) ? 'foo' : 'bar';
+
+$baz = ! isset($foo) ? 'foo' : 'baz';


### PR DESCRIPTION
Some to help starts with: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2.10/src/Fixer/Operator/TernaryToNullCoalescingFixer.php

Something to also be considering:
```php
if (isset($foo)) {
    $bar = $foo;
} elseif (isset($baz)) {
    $bar = $baz;
} else {
    $bar = 'quux';
}
```
Already proposed and voted in https://github.com/doctrine/coding-standard/pull/9#issuecomment-353871200