### PR TITLE
ForbiddenFunctions: Add more basic blackisted aliases

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -37,7 +37,33 @@
     <!-- Forbid deprecated functions -->
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <!-- Forbid alias functions, i.e. `sizeof()`, `delete()` -->
-    <rule ref="Generic.PHP.ForbiddenFunctions"/>
+    <rule ref="Generic.PHP.ForbiddenFunctions">
+        <properties>
+            <property
+                name="forbiddenFunctions"
+                type="array"
+                value="
+                    chop => rtrim,
+                    close => closedir,
+                    delete => unset,
+                    doubleval => floatval,
+                    fputs => fwrite,
+                    ini_alter => ini_set,
+                    is_double => is_float,
+                    is_integer => is_int,
+                    is_long => is_int,
+                    is_null => null,
+                    is_real => is_float,
+                    is_writeable => is_writable,
+                    join => implode,
+                    key_exists => array_key_exists,
+                    pos => current,
+                    show_source => highlight_file,
+                    sizeof => count,
+                    strchr => strstr
+                "/>
+        </properties>
+    </rule>
     <!-- Forbid useless inline string concatenation -->
     <rule ref="Generic.Strings.UnnecessaryStringConcat">
         <!-- But multiline is useful for readability -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -5,12 +5,13 @@ FILE                                                  ERRORS  WARNINGS
 ----------------------------------------------------------------------
 tests/input/concatenation_spacing.php                 24      0
 tests/input/example-class.php                         19      0
+tests/input/forbidden-functions.php                   3       0
 tests/input/not_spacing.php                           7       0
 tests/input/return_type_on_closures.php               21      0
 tests/input/return_type_on_methods.php                17      0
 tests/input/test-case.php                             6       0
 ----------------------------------------------------------------------
-A TOTAL OF 94 ERRORS AND 0 WARNINGS WERE FOUND IN 6 FILES
+A TOTAL OF 97 ERRORS AND 0 WARNINGS WERE FOUND IN 7 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 83 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------

--- a/tests/fixed/forbidden-functions.php
+++ b/tests/fixed/forbidden-functions.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test;
+
+use function chop;
+use function is_null;
+use function sizeof;
+
+echo chop('abc ');
+echo sizeof([1, 2, 3]);
+echo is_null(456) ? 'y' : 'n';

--- a/tests/input/forbidden-functions.php
+++ b/tests/input/forbidden-functions.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test;
+
+use function chop;
+use function is_null;
+use function sizeof;
+
+echo chop('abc ');
+echo sizeof([1, 2, 3]);
+echo is_null(456) ? 'y' : 'n';


### PR DESCRIPTION
Based on http://php.net/manual/en/aliases.php#aliases (thanks @carusogabriel for the link + https://github.com/squizlabs/PHP_CodeSniffer/pull/1838)

Currently contains only _Base syntax_ aliases.

Not auto-fixable. :/