### PR TITLE
Enable ForbiddenComments sniff

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -85,6 +85,19 @@
             />
         </properties>
     </rule>
+    <!-- Forbid useless comments -->
+    <rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments">
+        <properties>
+            <property
+                name="forbiddenCommentPatterns"
+                type="array"
+                value="
+                    ~^(?:(?!private|protected|static)\S+ )?(?:con|de)structor\.\z~i,
+                    ~^Created by \S+\.\z~i,
+                    ~^\S+ [gs]etter\.\z~i,
+                " />
+        </properties>
+    </rule>
     <!-- report invalid format of inline phpDocs with @var -->
     <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
     <!-- Forbid assignments in conditions -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -5,14 +5,15 @@ FILE                                                  ERRORS  WARNINGS
 ----------------------------------------------------------------------
 tests/input/concatenation_spacing.php                 24      0
 tests/input/example-class.php                         19      0
+tests/input/forbidden-comments.php                    4       0
 tests/input/not_spacing.php                           7       0
 tests/input/return_type_on_closures.php               21      0
 tests/input/return_type_on_methods.php                17      0
 tests/input/test-case.php                             6       0
 ----------------------------------------------------------------------
-A TOTAL OF 94 ERRORS AND 0 WARNINGS WERE FOUND IN 6 FILES
+A TOTAL OF 98 ERRORS AND 0 WARNINGS WERE FOUND IN 7 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 83 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 86 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/forbidden-comments.php
+++ b/tests/fixed/forbidden-comments.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test;
+
+class Foo
+{
+    public function __construct()
+    {
+        echo 'Hello';
+    }
+
+    public function getBar() : int
+    {
+        return 123;
+    }
+
+    /**
+     * Very important getter.
+     */
+    public function getBaz() : int
+    {
+        return 456;
+    }
+}

--- a/tests/input/forbidden-comments.php
+++ b/tests/input/forbidden-comments.php
@@ -1,0 +1,34 @@
+<?php
+
+/** Created by PhpStorm. */
+
+declare(strict_types=1);
+
+namespace Test;
+
+class Foo
+{
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        echo 'Hello';
+    }
+
+    /**
+     * Bar getter.
+     */
+    public function getBar() : int
+    {
+        return 123;
+    }
+
+    /**
+     * Very important getter.
+     */
+    public function getBaz() : int
+    {
+        return 456;
+    }
+}


### PR DESCRIPTION
Forbids useless things like:
```php
/** Created by PhpStorm. */
```
```php
/**
 * Constructor.
 */
```
```php
/**
 * Foo getter.
 */
```

Fixable, but with one issue: https://github.com/slevomat/coding-standard/issues/260