### PR TITLE
[RFC] Add more forbiddenAnnotations

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -100,12 +100,15 @@
                 name="forbiddenAnnotations"
                 type="array"
                 value="
+                    @api,
                     @author,
+                    @category,
                     @copyright,
                     @created,
                     @license,
                     @package,
                     @since,
+                    @subpackage,
                     @version
                 "
             />


### PR DESCRIPTION
There are some annotations in https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#7-tags that we some a few occurrences in our repos, but as minimal, I want to vote to forbidden them in our CS :smile: 