### PR TITLE
[RFC] Add SlevomatCodingStandard.PHP.TypeCast

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.1",
         "squizlabs/php_codesniffer": "^3.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.2",
-        "slevomat/coding-standard": "^4.4.0"
+        "slevomat/coding-standard": "^4.5.0"
     },
     "extra": {
         "branch-alias": {

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -177,6 +177,8 @@
     <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
     <!-- Forbid useless uses of the same namespace -->
     <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
+    <!-- Forbid use of longhand cast operators -->
+    <rule ref="SlevomatCodingStandard.PHP.TypeCast"/>
     <!-- Require presence of declare(strict_types=1) -->
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <properties>


### PR DESCRIPTION
Ref: https://github.com/slevomat/coding-standard/pull/284

Found 10 cases of `integer` cases in ORM, 13 cases of `boolean` in DBAL and 20 cases of `boolean` and 17 of `integer` in mongodb-odm