### PR TITLE
Force dependencies to specific versions to avoid BC breaks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
     },
     "require": {
         "php": "^7.1",
-        "squizlabs/php_codesniffer": "^3.2",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.2",
-        "slevomat/coding-standard": "^4.4.0"
+        "squizlabs/php_codesniffer": "3.2.2",
+        "dealerdirect/phpcodesniffer-composer-installer": "0.4.4",
+        "slevomat/coding-standard": "4.4.6"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
There are currently two BC breaks in bugfix release 3.2.3 of the PHP CodeSniffer:
* squizlabs/PHP_CodeSniffer#1909
* squizlabs/PHP_CodeSniffer#1911
This has already introduced build failures across some of Doctrine projects.

To prevent this, I want to lock the dependencies to specific versions. The cost for their manual updates is much smaller than the cost of fixing random build breakages.

Should be released as 3.0.1.