### PR TITLE
Add rules about exception types naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ exceptions/differences/extensions (:white_check_mark: are the implemented sniffs
 
 - Keep the nesting of control structures per method as small as possible
 - Prefer early exit over nesting conditions or using else
+- :white_check_mark: Abstract classes should not be prefixed with `Abstract`
+- :white_check_mark: Interfaces should not be suffixed with `Interface`
 - :white_check_mark: Concrete exception class names should not be suffixed with `Exception`
 - :white_check_mark: Abstract exception class names and exception interface names should be suffixed with `Exception`
 - :white_check_mark: Align equals (`=`) signs in assignments

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ exceptions/differences/extensions (:white_check_mark: are the implemented sniffs
 
 - Keep the nesting of control structures per method as small as possible
 - Prefer early exit over nesting conditions or using else
+- :white_check_mark: Concrete exception class names should not be suffixed with `Exception`
+- :white_check_mark: Abstract exception class names and exception interface names should be suffixed with `Exception`
 - :white_check_mark: Align equals (`=`) signs in assignments
 - :white_check_mark: Add spaces around a concatenation operator `$foo = 'Hello ' . 'World!';`
 - :white_check_mark: Add spaces between assignment, control and return statements

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.1",
         "squizlabs/php_codesniffer": "^3.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.2",
-        "slevomat/coding-standard": "^4.4.0"
+        "slevomat/coding-standard": "dev-master"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.1",
         "squizlabs/php_codesniffer": "^3.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.2",
-        "slevomat/coding-standard": "dev-master"
+        "slevomat/coding-standard": "^4.5.0"
     },
     "extra": {
         "branch-alias": {

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -93,6 +93,12 @@
     </rule>
     <!-- Forbid dead code -->
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
+    <!-- Forbid suffix "Abstract" for abstract classes -->
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
+    <!-- Forbid suffix "Exception" for exception classes -->
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
+    <!-- Forbid suffix "Interface" for interfaces -->
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
     <!-- Forbid useless annotations - Git and LICENCE file provide more accurate information -->
     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations">
         <properties>


### PR DESCRIPTION
You always know an exception is an exception when catching it or
throwing it, so the Exception suffix is useless, but hard to avoid when
you need to group exceptions together, which is why it should be present
in abstract exception names.
See http://mnapoli.fr/approaching-coding-style-rationally/#the-exception-suffix

This is the first of a series of goals I want to clarify regarding exceptions in Doctrine before trying to make a BC version of https://github.com/doctrine/doctrine2/pull/6743

At the moment, things are of course absolutely not like that, but I think that those rules could apply to newly-created exceptions.