### PR TITLE
Allow using doesNotPerformAssertions annotations

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -231,6 +231,7 @@
                     @dataProvider,
                     @depends,
                     @deprecated,
+                    @doesNotPerformAssertions,
                     @Enum,
                     @expectedDeprecation,
                     @expectedException,


### PR DESCRIPTION
The annotation is used in PHPUnit tests to mark tests without assertions as "not risky".

Note: `dev-master` currently contains changes that would constitute a BC break. I'd like to tag this as either 3.0.1 or 3.1.0 since I believe we should accumulate more changes before tagging 4.0.0. Opinions?