### PR TITLE
Enable RequireOneLinePropertyDocComment sniff

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -129,6 +129,8 @@
     </rule>
     <!-- report invalid format of inline phpDocs with @var -->
     <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
+    <!-- Require comments with single line written as one-liners -->
+    <rule ref="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment"/>
     <!-- Forbid assignments in conditions -->
     <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
     <!-- Forbid fancy yoda conditions -->


### PR DESCRIPTION
There is also counerpart sniff: DisallowOneLinePropertyDocComment.

I personally prefer the one-line variant, so starting with that one here.

ORM currently has lots of multilines for single undocumented `@var`.