### PR TITLE
Add rule about exception namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ exceptions/differences/extensions (:white_check_mark: are the implemented sniffs
 - Keep the nesting of control structures per method as small as possible
 - Prefer early exit over nesting conditions or using else
 - Abstract exception class names and exception interface names should be suffixed with `Exception`
+- Exceptions should live in an `Exception` sub-namespace of the namespace of the class that throws them.
 - :white_check_mark: Abstract classes should not be prefixed with `Abstract`
 - :white_check_mark: Interfaces should not be suffixed with `Interface`
 - :white_check_mark: Concrete exception class names should not be suffixed with `Exception`


### PR DESCRIPTION
Continuing the series of rules PRs, this is a more controversial one. Yay or Nay?

~~This will result in use statements, and will make spotting badly named
exceptions easier: if you are confused about a class being an exception
or not, then the naming is bad. Also, shallower trees. Things should be
grouped by feature/component, not by kind, no exceptions (pun intended).~~

Changed to `Exception` subnamespaces