### PR TITLE
[RFC] Use Elvis Operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ exceptions/differences/extensions (:white_check_mark: are the implemented sniffs
 - :white_check_mark: Assignment in condition is not allowed
 - :white_check_mark: Use parentheses when creating new instances that do not require arguments `$foo = new Foo()`
 - :white_check_mark: Use Null Coalesce Operator `$foo = $bar ?? $baz`
+- :white_check_mark: Use Elvis Operator `$foo = $bar ?: $baz`
 - :white_check_mark: Use early return
 
 For full reference of enforcements, go through `lib/Doctrine/ruleset.xml` where each sniff is briefly described.


### PR DESCRIPTION
We can refactor some ternary expressions when _first_ and _second_ operands are equal, with the Elvis Operator:
```diff
-$foo = $bar ? $bar : $baz;
+$foo = $bar ?: $baz;
```

/cc @kukulich I believe this will need a new Sniff :(

![image](https://user-images.githubusercontent.com/16328050/37205735-aa6a39c6-2374-11e8-8503-396b42dd8589.png)