### PR TITLE
Allow TODO annotation

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -267,6 +267,7 @@
                     @Target,
                     @test,
                     @throws,
+                    @TODO,
                     @uses
                 "
             />

--- a/tests/fixed/EarlyReturn.php
+++ b/tests/fixed/EarlyReturn.php
@@ -6,6 +6,9 @@ namespace Example;
 
 class EarlyReturn
 {
+    /**
+     * @TODO improve this method
+     */
     public function bar() : bool
     {
         if ($bar === 'bar') {

--- a/tests/input/EarlyReturn.php
+++ b/tests/input/EarlyReturn.php
@@ -6,6 +6,9 @@ namespace Example;
 
 class EarlyReturn
 {
+    /**
+     * @TODO improve this method
+     */
     public function bar() : bool
     {
         if ($bar === 'bar') {


### PR DESCRIPTION
Following https://github.com/doctrine/mongodb-odm/pull/1751#discussion_r173624289.

IMHO makes sense, as it's a good way to track future scopes. Also, if everyone agrees, should we only allow `TODO`, or `todo` is also okay?