### PR TITLE
Exclude SlevomatCodingStandard.ControlStructures.EarlyExit.UselessElseIf

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -146,7 +146,9 @@
     <!-- Forbid weak comparisons -->
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEqualOperators"/>
     <!-- Require usage of early exit -->
-    <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit">
+        <exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit.UselessElseIf"/>
+    </rule>
     <!-- Require language constructs without parentheses -->
     <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses"/>
     <!-- Require new instances with parentheses -->

--- a/tests/fixed/EarlyReturn.php
+++ b/tests/fixed/EarlyReturn.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Example;
 
+use function is_numeric;
+
 class EarlyReturn
 {
     public function bar() : bool
@@ -48,5 +50,18 @@ class EarlyReturn
         }
 
         return true;
+    }
+
+    public function qux() : int
+    {
+        if (is_numeric($var)) {
+            if ($var > 0) {
+                return 1;
+            } elseif ($var < 0) {
+                return -1;
+            }
+        }
+
+        return 0;
     }
 }

--- a/tests/input/EarlyReturn.php
+++ b/tests/input/EarlyReturn.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Example;
 
+use function is_numeric;
+
 class EarlyReturn
 {
     public function bar() : bool
@@ -48,5 +50,18 @@ class EarlyReturn
         }
 
         return true;
+    }
+
+    public function qux() : int
+    {
+        if (is_numeric($var)) {
+            if ($var > 0) {
+                return 1;
+            } elseif ($var < 0) {
+                return -1;
+            }
+        }
+
+        return 0;
     }
 }


### PR DESCRIPTION
I'm not entirely sure what side effects does it bring, but will fix something me and @alcaeus would like to see fixed :) Cross referencing https://github.com/doctrine/mongodb-odm/pull/1757