### PR TITLE
Revert "[RFC] Reference global classes via `use`" (re-vote)

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -168,7 +168,7 @@
         <properties>
             <property name="allowFallbackGlobalConstants" type="boolean" value="false"/>
             <property name="allowFallbackGlobalFunctions" type="boolean" value="false"/>
-            <property name="allowFullyQualifiedGlobalClasses" type="boolean" value="false"/>
+            <property name="allowFullyQualifiedGlobalClasses" type="boolean" value="true"/>
             <property name="allowFullyQualifiedGlobalConstants" type="boolean" value="false"/>
             <property name="allowFullyQualifiedGlobalFunctions" type="boolean" value="false"/>
             <property name="allowFullyQualifiedNameForCollidingClasses" type="boolean" value="true"/>

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -5,7 +5,7 @@ FILE                                                  ERRORS  WARNINGS
 ----------------------------------------------------------------------
 tests/input/concatenation_spacing.php                 24      0
 tests/input/EarlyReturn.php                           4       0
-tests/input/example-class.php                         22      0
+tests/input/example-class.php                         19      0
 tests/input/forbidden-comments.php                    4       0
 tests/input/forbidden-functions.php                   3       0
 tests/input/new_with_parentheses.php                  17      0
@@ -15,9 +15,9 @@ tests/input/return_type_on_closures.php               21      0
 tests/input/return_type_on_methods.php                17      0
 tests/input/test-case.php                             6       0
 ----------------------------------------------------------------------
-A TOTAL OF 128 ERRORS AND 0 WARNINGS WERE FOUND IN 11 FILES
+A TOTAL OF 125 ERRORS AND 0 WARNINGS WERE FOUND IN 11 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 113 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 110 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/example-class.php
+++ b/tests/fixed/example-class.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 namespace Example;
 
-use ArrayIterator;
 use Doctrine\Sniffs\Spacing\ControlStructureSniff;
 use Fancy\TestCase;
-use InvalidArgumentException;
-use IteratorAggregate;
 use const PHP_MINOR_VERSION;
 use const PHP_RELEASE_VERSION as PHP_PATCH_VERSION;
 use const PHP_VERSION;
@@ -19,7 +16,7 @@ use function substr;
 /**
  * Description
  */
-class Example implements IteratorAggregate
+class Example implements \IteratorAggregate
 {
     private const VERSION = PHP_VERSION - (PHP_MINOR_VERSION * 100) - PHP_PATCH_VERSION;
 
@@ -57,7 +54,7 @@ class Example implements IteratorAggregate
     public function getIterator() : array
     {
         assert($this->bar !== null);
-        return new ArrayIterator($this->bar);
+        return new \ArrayIterator($this->bar);
     }
 
     public function isBaz() : bool
@@ -68,7 +65,7 @@ class Example implements IteratorAggregate
     public function mangleBar(int $length) : void
     {
         if (! $this->baz) {
-            throw new InvalidArgumentException();
+            throw new \InvalidArgumentException();
         }
 
         $this->bar = (string) $this->baxBax ?? substr($this->bar, stringLength($this->bar - $length));


### PR DESCRIPTION
Reverts doctrine/coding-standard#43 - this is just to allow discussing whether this rule should be part of doctrine/coding-standard or not.

 * If you want it to stay, "request changes"
 * If you want it to go away, "approve"
