### PR TITLE
Forbidden usage of settype function

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -58,6 +58,7 @@
                     join => implode,
                     key_exists => array_key_exists,
                     pos => current,
+                    settype => null,
                     show_source => highlight_file,
                     sizeof => count,
                     strchr => strstr

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -7,7 +7,7 @@ tests/input/concatenation_spacing.php                 24      0
 tests/input/EarlyReturn.php                           4       0
 tests/input/example-class.php                         22      0
 tests/input/forbidden-comments.php                    4       0
-tests/input/forbidden-functions.php                   3       0
+tests/input/forbidden-functions.php                   4       0
 tests/input/new_with_parentheses.php                  17      0
 tests/input/not_spacing.php                           7       0
 tests/input/null_coalesce_operator.php                3       0
@@ -15,7 +15,7 @@ tests/input/return_type_on_closures.php               21      0
 tests/input/return_type_on_methods.php                17      0
 tests/input/test-case.php                             6       0
 ----------------------------------------------------------------------
-A TOTAL OF 128 ERRORS AND 0 WARNINGS WERE FOUND IN 11 FILES
+A TOTAL OF 129 ERRORS AND 0 WARNINGS WERE FOUND IN 11 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 113 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------

--- a/tests/fixed/forbidden-functions.php
+++ b/tests/fixed/forbidden-functions.php
@@ -6,8 +6,14 @@ namespace Test;
 
 use function chop;
 use function is_null;
+use function settype;
 use function sizeof;
+use function var_dump;
 
 echo chop('abc ');
 echo sizeof([1, 2, 3]);
 echo is_null(456) ? 'y' : 'n';
+
+$foo = '1';
+settype($foo, 'int');
+var_dump($foo);

--- a/tests/input/forbidden-functions.php
+++ b/tests/input/forbidden-functions.php
@@ -6,8 +6,14 @@ namespace Test;
 
 use function chop;
 use function is_null;
+use function settype;
 use function sizeof;
+use function var_dump;
 
 echo chop('abc ');
 echo sizeof([1, 2, 3]);
 echo is_null(456) ? 'y' : 'n';
+
+$foo = '1';
+settype($foo, 'int');
+var_dump($foo);


### PR DESCRIPTION
I'd like to propose the forbidden usage of the `settype` function. cast should be used instead:

```diff
<?php
$foo = '1';

-settype($foo, 'int');
+$foo = (int) $foo;

var_dump($foo); // int(1)
```