### PR TITLE
Replace inline docblock declarations with assertions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^7.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-        "slevomat/coding-standard": "dev-master",
+        "slevomat/coding-standard": "dev-master#63a8186b129ee96d1277e68c80cf87c8cdb356d1",
         "squizlabs/php_codesniffer": "^3.4.0"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^7.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-        "slevomat/coding-standard": "^5.0",
+        "slevomat/coding-standard": "dev-master",
         "squizlabs/php_codesniffer": "^3.4.0"
     },
     "config": {

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -311,6 +311,8 @@
     <rule ref="SlevomatCodingStandard.PHP.UselessParentheses"/>
     <!-- Forbid useless semicolon `;` -->
     <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
+    <!-- Require /* @var type $foo */ and similar simple inline annotations to be replaced by assert() -->
+    <rule ref="SlevomatCodingStandard.PHP.RequireExplicitAssertion"/>
     <!-- Require use of short versions of scalar types (i.e. int instead of integer) -->
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
     <!-- Require the `null` type hint to be in the last position of annotations -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -15,6 +15,7 @@ tests/input/EarlyReturn.php                           6       0
 tests/input/example-class.php                         33      0
 tests/input/forbidden-comments.php                    8       0
 tests/input/forbidden-functions.php                   6       0
+tests/input/inline_type_hint_assertions.php           5       0
 tests/input/LowCaseTypes.php                          2       0
 tests/input/namespaces-spacing.php                    7       0
 tests/input/new_with_parentheses.php                  18      0
@@ -34,9 +35,9 @@ tests/input/UnusedVariables.php                       1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 258 ERRORS AND 0 WARNINGS WERE FOUND IN 30 FILES
+A TOTAL OF 263 ERRORS AND 0 WARNINGS WERE FOUND IN 31 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 210 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 215 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -15,7 +15,7 @@ tests/input/EarlyReturn.php                           6       0
 tests/input/example-class.php                         33      0
 tests/input/forbidden-comments.php                    8       0
 tests/input/forbidden-functions.php                   6       0
-tests/input/inline_type_hint_assertions.php           5       0
+tests/input/inline_type_hint_assertions.php           6       0
 tests/input/LowCaseTypes.php                          2       0
 tests/input/namespaces-spacing.php                    7       0
 tests/input/new_with_parentheses.php                  18      0
@@ -35,9 +35,9 @@ tests/input/UnusedVariables.php                       1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 263 ERRORS AND 0 WARNINGS WERE FOUND IN 31 FILES
+A TOTAL OF 264 ERRORS AND 0 WARNINGS WERE FOUND IN 31 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 215 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 216 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/inline_type_hint_assertions.php
+++ b/tests/fixed/inline_type_hint_assertions.php
@@ -26,5 +26,7 @@ final class Foo
 
         $multipleScalarTypes = expression();
         assert(is_int($multipleScalarTypes) || is_float($multipleScalarTypes) || is_bool($multipleScalarTypes) || is_string($multipleScalarTypes) || $multipleScalarTypes === null || is_array($multipleScalarTypes));
+
+        assert($variableThatIsNowhereToBeFound instanceof Potato);
     }
 }

--- a/tests/fixed/inline_type_hint_assertions.php
+++ b/tests/fixed/inline_type_hint_assertions.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+final class Foo
+{
+    public function methodWithInlineHints()
+    {
+        $simpleType = expression();
+        assert($simpleType instanceof Type);
+
+        $typeDeclaredAfterExpression = expression();
+        assert($typeDeclaredAfterExpression instanceof Type);
+
+        $typeDeclaredViaAssertion = expression();
+        assert($typeDeclaredViaAssertion instanceof Type);
+
+        $unionType = expression();
+        assert($unionType instanceof Type1 || $unionType instanceof Type2);
+
+        $intersectionType = expression();
+        assert($intersectionType instanceof Type1 && $intersectionType instanceof Type2);
+
+        $nullableType = expression();
+        assert($nullableType instanceof Type || $nullableType === null);
+
+        $multipleScalarTypes = expression();
+        assert(is_int($multipleScalarTypes) || is_float($multipleScalarTypes) || is_bool($multipleScalarTypes) || is_string($multipleScalarTypes) || $multipleScalarTypes === null || is_array($multipleScalarTypes));
+    }
+}

--- a/tests/fixed/inline_type_hint_assertions.php
+++ b/tests/fixed/inline_type_hint_assertions.php
@@ -6,7 +6,7 @@ $simpleType = expression();
 assert($simpleType instanceof Type);
 
 $typeDeclaredAfterExpression = expression();
-/** @var Type $typeDeclaredAfterExpression */
+assert($typeDeclaredAfterExpression instanceof Type);
 
 $typeDeclaredViaAssertion = expression();
 assert($typeDeclaredViaAssertion instanceof Type);

--- a/tests/fixed/inline_type_hint_assertions.php
+++ b/tests/fixed/inline_type_hint_assertions.php
@@ -2,31 +2,25 @@
 
 declare(strict_types=1);
 
-final class Foo
-{
-    public function methodWithInlineHints()
-    {
-        $simpleType = expression();
-        assert($simpleType instanceof Type);
+$simpleType = expression();
+assert($simpleType instanceof Type);
 
-        $typeDeclaredAfterExpression = expression();
-        assert($typeDeclaredAfterExpression instanceof Type);
+$typeDeclaredAfterExpression = expression();
+assert($typeDeclaredAfterExpression instanceof Type);
 
-        $typeDeclaredViaAssertion = expression();
-        assert($typeDeclaredViaAssertion instanceof Type);
+$typeDeclaredViaAssertion = expression();
+assert($typeDeclaredViaAssertion instanceof Type);
 
-        $unionType = expression();
-        assert($unionType instanceof Type1 || $unionType instanceof Type2);
+$unionType = expression();
+assert($unionType instanceof Type1 || $unionType instanceof Type2);
 
-        $intersectionType = expression();
-        assert($intersectionType instanceof Type1 && $intersectionType instanceof Type2);
+$intersectionType = expression();
+assert($intersectionType instanceof Type1 && $intersectionType instanceof Type2);
 
-        $nullableType = expression();
-        assert($nullableType instanceof Type || $nullableType === null);
+$nullableType = expression();
+assert($nullableType instanceof Type || $nullableType === null);
 
-        $multipleScalarTypes = expression();
-        assert(is_int($multipleScalarTypes) || is_float($multipleScalarTypes) || is_bool($multipleScalarTypes) || is_string($multipleScalarTypes) || $multipleScalarTypes === null || is_array($multipleScalarTypes));
+$multipleScalarTypes = expression();
+assert(is_int($multipleScalarTypes) || is_float($multipleScalarTypes) || is_bool($multipleScalarTypes) || is_string($multipleScalarTypes) || is_array($multipleScalarTypes) || $multipleScalarTypes === null);
 
-        assert($variableThatIsNowhereToBeFound instanceof Potato);
-    }
-}
+assert($variableThatIsNowhereToBeFound instanceof Potato);

--- a/tests/fixed/inline_type_hint_assertions.php
+++ b/tests/fixed/inline_type_hint_assertions.php
@@ -6,7 +6,7 @@ $simpleType = expression();
 assert($simpleType instanceof Type);
 
 $typeDeclaredAfterExpression = expression();
-assert($typeDeclaredAfterExpression instanceof Type);
+/** @var Type $typeDeclaredAfterExpression */
 
 $typeDeclaredViaAssertion = expression();
 assert($typeDeclaredViaAssertion instanceof Type);
@@ -23,4 +23,4 @@ assert($nullableType instanceof Type || $nullableType === null);
 $multipleScalarTypes = expression();
 assert(is_int($multipleScalarTypes) || is_float($multipleScalarTypes) || is_bool($multipleScalarTypes) || is_string($multipleScalarTypes) || is_array($multipleScalarTypes) || $multipleScalarTypes === null);
 
-assert($variableThatIsNowhereToBeFound instanceof Potato);
+/** @var Potato $variableThatIsNowhereToBeFound */

--- a/tests/input/inline_type_hint_assertions.php
+++ b/tests/input/inline_type_hint_assertions.php
@@ -26,5 +26,7 @@ final class Foo
 
         /** @var int|float|bool|string|null|array $multipleScalarTypes */
         $multipleScalarTypes = expression();
+
+        /** @var Potato $variableThatIsNowhereToBeFound */
     }
 }

--- a/tests/input/inline_type_hint_assertions.php
+++ b/tests/input/inline_type_hint_assertions.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+final class Foo
+{
+    public function methodWithInlineHints()
+    {
+        /** @var Type $simpleType */
+        $simpleType = expression();
+
+        $typeDeclaredAfterExpression = expression();
+        /** @var Type $typeDeclaredAfterExpression */
+
+        $typeDeclaredViaAssertion = expression();
+        assert($typeDeclaredViaAssertion instanceof Type);
+
+        /** @var Type1|Type2 $unionType */
+        $unionType = expression();
+
+        /** @var Type1&Type2 $intersectionType */
+        $intersectionType = expression();
+
+        /** @var Type|null $nullableType */
+        $nullableType = expression();
+
+        /** @var int|float|bool|string|null|array $multipleScalarTypes */
+        $multipleScalarTypes = expression();
+    }
+}

--- a/tests/input/inline_type_hint_assertions.php
+++ b/tests/input/inline_type_hint_assertions.php
@@ -2,31 +2,25 @@
 
 declare(strict_types=1);
 
-final class Foo
-{
-    public function methodWithInlineHints()
-    {
-        /** @var Type $simpleType */
-        $simpleType = expression();
+/** @var Type $simpleType */
+$simpleType = expression();
 
-        $typeDeclaredAfterExpression = expression();
-        /** @var Type $typeDeclaredAfterExpression */
+$typeDeclaredAfterExpression = expression();
+/** @var Type $typeDeclaredAfterExpression */
 
-        $typeDeclaredViaAssertion = expression();
-        assert($typeDeclaredViaAssertion instanceof Type);
+$typeDeclaredViaAssertion = expression();
+assert($typeDeclaredViaAssertion instanceof Type);
 
-        /** @var Type1|Type2 $unionType */
-        $unionType = expression();
+/** @var Type1|Type2 $unionType */
+$unionType = expression();
 
-        /** @var Type1&Type2 $intersectionType */
-        $intersectionType = expression();
+/** @var Type1&Type2 $intersectionType */
+$intersectionType = expression();
 
-        /** @var Type|null $nullableType */
-        $nullableType = expression();
+/** @var Type|null $nullableType */
+$nullableType = expression();
 
-        /** @var int|float|bool|string|null|array $multipleScalarTypes */
-        $multipleScalarTypes = expression();
+/** @var int|float|bool|string|array|null $multipleScalarTypes */
+$multipleScalarTypes = expression();
 
-        /** @var Potato $variableThatIsNowhereToBeFound */
-    }
-}
+/** @var Potato $variableThatIsNowhereToBeFound */


### PR DESCRIPTION
This RFC proposes replacing the typical `/** @var Something $something */` with `assert($something instanceof Something)` wherever possible.

This has a few nice side-effects that @dasprid exposed:

 1. the type declaration is no longer a comment, but AST nodes that can be inspected and have well defined meaning in the language itself
 2. `assert()` can report when these assumptions fail (once the CS rule is applied to a codebase)
 3. `assert()` can be turned off, making this an informational addition

I didn't dig into PHPStan's new type declarations, which support `foo[]`, `(foo|bar)[]` and union types (`foo&bar`) too much, so this is just a first sketch of the idea I stole from @dasprid.