### PR TITLE
Forbidden usage of extract

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -47,6 +47,7 @@
                     close => closedir,
                     delete => unset,
                     doubleval => floatval,
+                    extract => null,
                     fputs => fwrite,
                     ini_alter => ini_set,
                     is_double => is_float,

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -7,7 +7,7 @@ tests/input/concatenation_spacing.php                 24      0
 tests/input/EarlyReturn.php                           4       0
 tests/input/example-class.php                         22      0
 tests/input/forbidden-comments.php                    4       0
-tests/input/forbidden-functions.php                   4       0
+tests/input/forbidden-functions.php                   5       0
 tests/input/new_with_parentheses.php                  17      0
 tests/input/not_spacing.php                           7       0
 tests/input/null_coalesce_operator.php                3       0
@@ -15,7 +15,7 @@ tests/input/return_type_on_closures.php               21      0
 tests/input/return_type_on_methods.php                17      0
 tests/input/test-case.php                             6       0
 ----------------------------------------------------------------------
-A TOTAL OF 129 ERRORS AND 0 WARNINGS WERE FOUND IN 11 FILES
+A TOTAL OF 130 ERRORS AND 0 WARNINGS WERE FOUND IN 11 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 113 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------

--- a/tests/fixed/forbidden-functions.php
+++ b/tests/fixed/forbidden-functions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Test;
 
 use function chop;
+use function extract;
 use function is_null;
 use function settype;
 use function sizeof;
@@ -17,3 +18,10 @@ echo is_null(456) ? 'y' : 'n';
 $foo = '1';
 settype($foo, 'int');
 var_dump($foo);
+
+$bar = [
+    'foo' => 1,
+    'bar' => 2,
+    'baz' => 3,
+];
+extract($bar);

--- a/tests/input/forbidden-functions.php
+++ b/tests/input/forbidden-functions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Test;
 
 use function chop;
+use function extract;
 use function is_null;
 use function settype;
 use function sizeof;
@@ -17,3 +18,10 @@ echo is_null(456) ? 'y' : 'n';
 $foo = '1';
 settype($foo, 'int');
 var_dump($foo);
+
+$bar = [
+    'foo' => 1,
+    'bar' => 2,
+    'baz' => 3,
+];
+extract($bar);


### PR DESCRIPTION
I'd like to propose the forbidden usage of the `extract` function. `list` should be used instead.

Some reasons are:
- PHPStan does not recognize the extracted variables
- Sometimes we don't want to whole `array`'s indexes, just some of them
- Control of the extract variables names and values

When #39 gets merged, and this one gets approved, `list` will turn into `[]` :+1: 

```diff
<?php

$bar = [
    'foo' => 1,
    'bar' => 2,
    'baz' => 3,
];
-extract($bar);
+list($fooValue, $barValue, $bazValue) = $bar;
```