### PR TITLE
Forbidden usage of compact

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -45,6 +45,7 @@
                 value="
                     chop => rtrim,
                     close => closedir,
+                    compact => null,
                     delete => unset,
                     doubleval => floatval,
                     extract => null,

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -7,7 +7,7 @@ tests/input/concatenation_spacing.php                 24      0
 tests/input/EarlyReturn.php                           4       0
 tests/input/example-class.php                         22      0
 tests/input/forbidden-comments.php                    4       0
-tests/input/forbidden-functions.php                   5       0
+tests/input/forbidden-functions.php                   6       0
 tests/input/new_with_parentheses.php                  17      0
 tests/input/not_spacing.php                           7       0
 tests/input/null_coalesce_operator.php                3       0
@@ -15,7 +15,7 @@ tests/input/return_type_on_closures.php               21      0
 tests/input/return_type_on_methods.php                17      0
 tests/input/test-case.php                             6       0
 ----------------------------------------------------------------------
-A TOTAL OF 130 ERRORS AND 0 WARNINGS WERE FOUND IN 11 FILES
+A TOTAL OF 131 ERRORS AND 0 WARNINGS WERE FOUND IN 11 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 113 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------

--- a/tests/fixed/forbidden-functions.php
+++ b/tests/fixed/forbidden-functions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Test;
 
 use function chop;
+use function compact;
 use function extract;
 use function is_null;
 use function settype;
@@ -25,3 +26,5 @@ $bar = [
     'baz' => 3,
 ];
 extract($bar);
+
+compact('foo', 'bar');

--- a/tests/input/forbidden-functions.php
+++ b/tests/input/forbidden-functions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Test;
 
 use function chop;
+use function compact;
 use function extract;
 use function is_null;
 use function settype;
@@ -25,3 +26,5 @@ $bar = [
     'baz' => 3,
 ];
 extract($bar);
+
+compact('foo', 'bar');


### PR DESCRIPTION
As suggested by @Ocramius in #48 :)

A reason pointed by @morozov is that it initializes unknown/unpredictable variables in the local scope.

A simple array should be used instead:
```diff
<?php
$foo = [
    'bar' => 1,
];

-return compact('foo');
+return [
+    'foo' => $foo['bar'],
+];
```