### PR TITLE
Enable UseSpacing sniff

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -3,7 +3,10 @@
     <description>The Doctrine coding standard.</description>
 
     <!-- Import PSR-2 coding standard (base) -->
-    <rule ref="PSR2"/>
+    <rule ref="PSR2">
+        <!-- checked by SlevomatCodingStandard.Namespaces.UseSpacing -->
+        <exclude name="PSR2.Namespaces.UseDeclaration.SpaceAfterLastUse"/>
+    </rule>
 
     <!-- Forbid `array(...)` -->
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
@@ -190,6 +193,14 @@
     <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
     <!-- Forbid useless uses of the same namespace -->
     <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
+    <!-- Require empty newlines before and after uses -->
+    <rule ref="SlevomatCodingStandard.Namespaces.UseSpacing">
+        <properties>
+            <property name="linesCountAfterLastUse" value="1"/>
+            <property name="linesCountBeforeFirstUse" value="1"/>
+            <property name="linesCountBetweenUseTypes" value="0"/>
+        </properties>
+    </rule>
     <!-- Forbid use of longhand cast operators -->
     <rule ref="SlevomatCodingStandard.PHP.TypeCast"/>
     <!-- Require presence of declare(strict_types=1) -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -8,6 +8,7 @@ tests/input/EarlyReturn.php                           4       0
 tests/input/example-class.php                         22      0
 tests/input/forbidden-comments.php                    4       0
 tests/input/forbidden-functions.php                   6       0
+tests/input/namespaces-spacing.php                    6       0
 tests/input/new_with_parentheses.php                  17      0
 tests/input/not_spacing.php                           7       0
 tests/input/null_coalesce_operator.php                3       0
@@ -15,9 +16,9 @@ tests/input/return_type_on_closures.php               21      0
 tests/input/return_type_on_methods.php                17      0
 tests/input/test-case.php                             6       0
 ----------------------------------------------------------------------
-A TOTAL OF 131 ERRORS AND 0 WARNINGS WERE FOUND IN 11 FILES
+A TOTAL OF 137 ERRORS AND 0 WARNINGS WERE FOUND IN 12 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 113 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 119 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/namespaces-spacing.php
+++ b/tests/fixed/namespaces-spacing.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Foo;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use const DATE_RFC3339;
+use function strrev;
+use function time;
+
+strrev(
+    (new DateTimeImmutable('@' . time(), new DateTimeZone('UTC')))
+        ->sub(new DateInterval('P1D'))
+        ->format(DATE_RFC3339)
+);

--- a/tests/input/namespaces-spacing.php
+++ b/tests/input/namespaces-spacing.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+namespace Foo;
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+
+use const DATE_RFC3339;
+
+use function strrev;
+use function time;
+strrev(
+    (new DateTimeImmutable('@' . time(), new DateTimeZone('UTC')))
+        ->sub(new DateInterval('P1D'))
+        ->format(DATE_RFC3339)
+);


### PR DESCRIPTION
https://github.com/slevomat/coding-standard/commit/e5e3a25327abf80afad3bf8b34218dfcbd079140

In Slevomat CS since 4.5.0, but completely missed (wasn't in release notes).

* One empty line before `use`s.
* No empty lines between different use types.
* One empty line after `use`s.