### PR TITLE
Exclude Squiz.Commenting.FunctionComment.ThrowsNotCapital sniff

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -349,6 +349,9 @@
         <exclude name="Squiz.Commenting.FunctionComment.ParamNameNoMatch"/>
         <!-- Doesn't respect inheritance -->
         <exclude name="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing"/>
+        <!-- `@throws` lines can often be read as a sentence,
+             i.e. `@throws RuntimeException if the file could not be written.` -->
+        <exclude name="Squiz.Commenting.FunctionComment.ThrowsNotCapital"/>
         <!-- Doesn't work with self as typehint -->
         <exclude name="Squiz.Commenting.FunctionComment.TypeHintMissing"/>
     </rule>

--- a/tests/fixed/example-class.php
+++ b/tests/fixed/example-class.php
@@ -65,6 +65,9 @@ class Example implements IteratorAggregate
         return $this->baz;
     }
 
+    /**
+     * @throws InvalidArgumentException if this example cannot baz.
+     */
     public function mangleBar(int $length) : void
     {
         if (! $this->baz) {

--- a/tests/input/example-class.php
+++ b/tests/input/example-class.php
@@ -61,6 +61,9 @@ class Example implements \IteratorAggregate
         return $this->baz;
     }
 
+    /**
+     * @throws InvalidArgumentException if this example cannot baz.
+     */
     public function mangleBar(int $length) : void
     {
         if (!$this->baz) {


### PR DESCRIPTION
I suggest allowing descriptions for `@throws` to be started with a non-capital letter as it is more natural to compose a complete sentence out of the line like:

```
 @throws RuntimeException if the file could not be written.
```

As a further improvement one might even enforce sentences like this (starting with `if`).
What do you guys think?