### PR TITLE
Require increment and decrement operators

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -360,6 +360,8 @@
     </rule>
     <!-- Forbid global functions -->
     <rule ref="Squiz.Functions.GlobalFunction"/>
+    <!-- Require increment and decrement operators -->
+    <rule ref="Squiz.Operators.IncrementDecrementUsage"/>
     <!-- Forbid `AND` and `OR`, require `&&` and `||` -->
     <rule ref="Squiz.Operators.ValidLogicalOperators"/>
     <!-- Forbid `global` -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -9,6 +9,7 @@ tests/input/EarlyReturn.php                           4       0
 tests/input/example-class.php                         22      0
 tests/input/forbidden-comments.php                    4       0
 tests/input/forbidden-functions.php                   6       0
+tests/input/increment-decrement.php                   2       0
 tests/input/namespaces-spacing.php                    6       0
 tests/input/new_with_parentheses.php                  18      0
 tests/input/not_spacing.php                           7       0
@@ -18,7 +19,7 @@ tests/input/return_type_on_methods.php                17      0
 tests/input/semicolon_spacing.php                     3       0
 tests/input/test-case.php                             6       0
 ----------------------------------------------------------------------
-A TOTAL OF 151 ERRORS AND 0 WARNINGS WERE FOUND IN 14 FILES
+A TOTAL OF 153 ERRORS AND 0 WARNINGS WERE FOUND IN 15 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 133 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------

--- a/tests/fixed/increment-decrement.php
+++ b/tests/fixed/increment-decrement.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+$i++;
+$i += 1;
+$j += 2;
+$j -= 1;

--- a/tests/input/increment-decrement.php
+++ b/tests/input/increment-decrement.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+$i++;
+$i += 1;
+$j += 2;
+$j -= 1;


### PR DESCRIPTION
Will be useful to keep our `for` standards:
```diff
-for ($i = 0; $i < 10; $i += 1) {
+for ($i = 0; $i < 10; $i++) {
```

Unfortunately, this is not an auto-fixable Sniff.