### PR TITLE
Enable DisallowShortTernaryOperator sniff (not fixable)

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -159,6 +159,12 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
     <!-- Forbid weak comparisons -->
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEqualOperators"/>
+    <!-- Forbid short form of ternary operator (?:) -->
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowShortTernaryOperator">
+        <properties>
+            <property name="fixable" type="boolean" value="false"/>
+        </properties>
+    </rule>
     <!-- Require usage of early exit -->
     <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
     <!-- Require language constructs without parentheses -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -16,9 +16,10 @@ tests/input/null_coalesce_operator.php                3       0
 tests/input/return_type_on_closures.php               21      0
 tests/input/return_type_on_methods.php                17      0
 tests/input/semicolon_spacing.php                     3       0
+tests/input/short_ternary.php                         1       0
 tests/input/test-case.php                             6       0
 ----------------------------------------------------------------------
-A TOTAL OF 153 ERRORS AND 0 WARNINGS WERE FOUND IN 14 FILES
+A TOTAL OF 154 ERRORS AND 0 WARNINGS WERE FOUND IN 15 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 135 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------

--- a/tests/fixed/new_with_parentheses.php
+++ b/tests/fixed/new_with_parentheses.php
@@ -24,5 +24,5 @@ $y = [new stdClass()];
 
 $z = new stdClass() ? new stdClass() : new stdClass();
 
-$q = $q ?: new stdClass();
+$q = $q ? $qq : new stdClass();
 $e = $e ?? new stdClass();

--- a/tests/fixed/short_ternary.php
+++ b/tests/fixed/short_ternary.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+$x ?: $y;

--- a/tests/input/new_with_parentheses.php
+++ b/tests/input/new_with_parentheses.php
@@ -24,5 +24,5 @@ $y = [new stdClass];
 
 $z = new stdClass ? new stdClass : new stdClass;
 
-$q = $q ?: new stdClass;
+$q = $q ? $qq : new stdClass;
 $e = $e ?? new stdClass;

--- a/tests/input/short_ternary.php
+++ b/tests/input/short_ternary.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+$x ?: $y;


### PR DESCRIPTION
Here's a proposal to ban short form of ternary operator: `?:`

This form implicitly and by design uses boolean coercion for the value - this is incompatible with strict code and _PHPStan strict rules_ (yet to come in 0.10).

The following is forbidden:
```php
$anything ?: $default
```
Correct replacement is either null coalesce operator (for nullable value) or explicit full ternary with strict condition:
```php
$anything ?? $default
$anything !== '' ? $anything : $default
```

_Waiting for Slevomat CS 4.6, should be released soon._

![](https://user-images.githubusercontent.com/144181/39794708-03f9c8a6-534c-11e8-984d-4d66a40ab901.png)
