### PR TITLE
Enable DisallowEmpty sniff

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -157,6 +157,8 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
     <!-- Forbid fancy yoda conditions -->
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
+    <!-- Forbid weak empty() -->
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEmpty"/>
     <!-- Forbid weak comparisons -->
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEqualOperators"/>
     <!-- Require usage of early exit -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -6,6 +6,7 @@ FILE                                                  ERRORS  WARNINGS
 tests/input/array_indentation.php                     10      0
 tests/input/concatenation_spacing.php                 24      0
 tests/input/EarlyReturn.php                           4       0
+tests/input/empty.php                                 1       0
 tests/input/example-class.php                         23      0
 tests/input/forbidden-comments.php                    4       0
 tests/input/forbidden-functions.php                   6       0
@@ -18,7 +19,7 @@ tests/input/return_type_on_methods.php                17      0
 tests/input/semicolon_spacing.php                     3       0
 tests/input/test-case.php                             6       0
 ----------------------------------------------------------------------
-A TOTAL OF 153 ERRORS AND 0 WARNINGS WERE FOUND IN 14 FILES
+A TOTAL OF 154 ERRORS AND 0 WARNINGS WERE FOUND IN 15 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 135 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------

--- a/tests/fixed/empty.php
+++ b/tests/fixed/empty.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+empty($x);

--- a/tests/input/empty.php
+++ b/tests/input/empty.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+empty($x);


### PR DESCRIPTION
Here's a proposal to ban `empty()` construct.

Its weakly typed behavior is incompatible with strict code and _PHPStan strict rules_ (yet to come in 0.10).

The following is forbidden:
```php
empty($foo)
```
Correct replacement is either using `isset()` (for possibly undefined value), null coalesce operator or strict comparison:
```php
isset($foo)
$foo ?? 123
$foo !== []
```

_Waiting for Slevomat CS 4.6, should be released soon._

![](https://user-images.githubusercontent.com/144181/39794708-03f9c8a6-534c-11e8-984d-4d66a40ab901.png)
