### PR TITLE
Enable NamespaceSpacing sniff

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0.x-dev"
+            "dev-master": "5.0.x-dev"
         }
     }
 }

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -10,6 +10,8 @@
     <rule ref="PSR2">
         <!-- checked by SlevomatCodingStandard.Namespaces.UseSpacing -->
         <exclude name="PSR2.Namespaces.UseDeclaration.SpaceAfterLastUse"/>
+        <!-- checked by SlevomatCodingStandard.Namespaces.NamespaceSpacing -->
+        <exclude name="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter"/>
     </rule>
 
     <!-- Force array element indentation with 4 spaces -->
@@ -175,6 +177,8 @@
     <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
     <!-- Forbid multiple use statements on same line -->
     <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine"/>
+    <!-- Require newlines around namespace declaration -->
+    <rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing"/>
     <!-- Forbid using absolute class name references (except global ones) -->
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
         <properties>

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -9,7 +9,7 @@ tests/input/EarlyReturn.php                           4       0
 tests/input/example-class.php                         23      0
 tests/input/forbidden-comments.php                    4       0
 tests/input/forbidden-functions.php                   6       0
-tests/input/namespaces-spacing.php                    6       0
+tests/input/namespaces-spacing.php                    7       0
 tests/input/new_with_parentheses.php                  18      0
 tests/input/not_spacing.php                           7       0
 tests/input/null_coalesce_operator.php                3       0
@@ -18,9 +18,9 @@ tests/input/return_type_on_methods.php                17      0
 tests/input/semicolon_spacing.php                     3       0
 tests/input/test-case.php                             6       0
 ----------------------------------------------------------------------
-A TOTAL OF 152 ERRORS AND 0 WARNINGS WERE FOUND IN 14 FILES
+A TOTAL OF 153 ERRORS AND 0 WARNINGS WERE FOUND IN 14 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 134 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 135 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 


### PR DESCRIPTION
Simply one empty line before and one after `namespace`.

_Waiting for Slevomat CS 4.6, should be released soon._