### PR TITLE
Lock Slevomat CS to install only patch releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.1",
         "squizlabs/php_codesniffer": "^3.2.3",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.2",
-        "slevomat/coding-standard": "^4.6.0"
+        "slevomat/coding-standard": "~4.6.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Minor release can cause failing builds, see https://github.com/Roave/BetterReflection/pull/424