### PR TITLE
Improve short list syntax rule description

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -211,7 +211,7 @@
             <property name="linesCountBetweenUseTypes" value="0"/>
         </properties>
     </rule>
-    <!-- Forbid use of list() -->
+    <!-- Forbid `list(...)` syntax -->
     <rule ref="SlevomatCodingStandard.PHP.ShortList"/>
     <!-- Forbid use of longhand cast operators -->
     <rule ref="SlevomatCodingStandard.PHP.TypeCast"/>


### PR DESCRIPTION
The previous description gave us the idea that `list` was a forbidden function/struct :)