### PR TITLE
Remove duplicated ShortOpenTags

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -87,8 +87,6 @@
     </rule>
     <!-- Forbid backtick operator -->
     <rule ref="Generic.PHP.BacktickOperator"/>
-    <!-- Forbid short open tag -->
-    <rule ref="Generic.PHP.DisallowShortOpenTag"/>
     <!-- Forbid `php_sapi_name()` function -->
     <rule ref="Generic.PHP.SAPIUsage"/>
     <!-- Forbid comments starting with # -->


### PR DESCRIPTION
This is already part of [PSR-1](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/PSR1/ruleset.xml#L10).