### PR TITLE
Add some docs to the doctrine/coding-standard project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,103 +1,13 @@
-Doctrine Coding Standard
-========================
+# Doctrine Coding Standard
 
 [![Build Status](https://img.shields.io/travis/doctrine/coding-standard/master.svg?style=flat-square)](http://travis-ci.org/doctrine/coding-standard)
 [![Total Downloads](https://img.shields.io/packagist/dt/doctrine/coding-standard.svg?style=flat-square)](https://packagist.org/packages/doctrine/coding-standard)
 [![Latest Stable Version](https://img.shields.io/packagist/v/doctrine/coding-standard.svg?style=flat-square)](https://packagist.org/packages/doctrine/coding-standard)
 
+The Doctrine Coding Standard is a set of [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) rules applied to all Doctrine projects. Doctrine Coding Standard is heavily based on [Slevomat Coding Standard](https://github.com/slevomat/coding-standard).
 
-The [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) ruleset to check that
-repositories are following the standards defined by the Doctrine team.
+## More resources:
 
-Standards
----------
-
-Doctrine Coding Standard is based on [PSR-1](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md)
-and [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md), with some noticeable
-exceptions/differences/extensions (:white_check_mark: are the implemented sniffs):
-
-- Keep the nesting of control structures per method as small as possible
-- Abstract exception class names and exception interface names should be suffixed with `Exception`
-- :white_check_mark: Abstract classes should not be prefixed with `Abstract`
-- :white_check_mark: Interfaces should not be suffixed with `Interface`
-- :white_check_mark: Concrete exception class names should not be suffixed with `Exception`
-- :white_check_mark: Align equals (`=`) signs in assignments
-- :white_check_mark: Add spaces around a concatenation operator `$foo = 'Hello ' . 'World!';`
-- :white_check_mark: Add spaces between assignment, control and return statements
-- :white_check_mark: Add spaces after a negation operator `if (! $cond)`
-- :white_check_mark: Add spaces around a colon in return type declaration `function () : void {}`
-- :white_check_mark: Add spaces after a type cast `$foo = (int) '12345';`
-- :white_check_mark: Use apostrophes for enclosing strings
-- :white_check_mark: Always use strict comparisons
-- :white_check_mark: Always add `declare(strict_types=1)` at the beginning of a file
-- :white_check_mark: Always add native types where possible
-- :white_check_mark: Omit phpDoc for parameters/returns with native types, unless adding description
-- :white_check_mark: Don't use `@author`, `@since` and similar annotations that duplicate Git information
-- :white_check_mark: Assignment in condition is not allowed
-- :white_check_mark: Use parentheses when creating new instances that do not require arguments `$foo = new Foo()`
-- :white_check_mark: Use Null Coalesce Operator `$foo = $bar ?? $baz`
-- :white_check_mark: Prefer early exit over nesting conditions or using else
-
-For full reference of enforcements, go through `lib/Doctrine/ruleset.xml` where each sniff is briefly described.
-
-Installation
-------------
-
-You have two possibilities to use the Doctrine Coding Standard with PHP_CodeSniffer in a particular project.
-
-### 1. As a composer dependency of your project
-
-You can install the Doctrine Coding Standard as a composer dependency to your particular project.
-Just add the following block to your project's `composer.json` file:
-
-```bash
-$ php composer require --dev doctrine/coding-standard
-```
-
-Then you can use it like:
-
-```bash
-$ ./vendor/bin/phpcs --standard=Doctrine /path/to/some/file/to/sniff.php
-```
-
-You might also do automatic fixes using `phpcbf`:
-
-```bash
-$ ./vendor/bin/phpcbf --standard=Doctrine /path/to/some/file/to/sniff.php
-```
-
-### 2. Global installation
-
-You can also install the Doctrine Coding Standard globally:
-
-```bash
-$ composer global require doctrine/coding-standard
-```
-
-Then you can use it like:
-
-```bash
-$ phpcs --standard=Doctrine /path/to/some/file/to/sniff.php
-```
-
-You might also do automatic fixes using `phpcbf`:
-
-```bash
-$ phpcbf --standard=Doctrine /path/to/some/file/to/sniff.php
-```
-
-Versioning
-----------
-
-This library follows semantic versioning, and additions to the code ruleset
-are only performed in major releases.
-
-Testing
--------
-
-If you are contributing to the Doctrine Coding Standard and want to test your contribution, you just
-need to execute PHPCS with the tests folder and ensure it matches the expected report:
-
-```bash
-$ ./vendor/bin/phpcs tests/input --report=summary --report-file=phpcs.log; diff tests/expected_report.txt phpcs.log
-```
+* [Website](https://www.doctrine-project.org/)
+* [Documentation](https://www.doctrine-project.org/projects/doctrine-coding-standard/en/latest/)
+* [Downloads](https://github.com/doctrine/coding-standard/coding-standard)

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -1,0 +1,22 @@
+Coding Standards Documentation
+==============================
+
+The Doctrine Coding Standards documentation is a reference guide to everything you need
+to know about the coding standards project.
+
+Getting Help
+------------
+
+If this documentation is not helping to answer questions you have about
+Doctrine Coding Standards don't panic. You can get help from different sources:
+
+-  The `Doctrine Mailing List <https://groups.google.com/group/doctrine-user>`_
+-  Gitter chat room `#doctrine/coding-standard <https://gitter.im/doctrine/coding-standard>`_
+-  Report a bug on `GitHub <https://github.com/doctrine/coding-standard/issues>`_.
+-  On `StackOverflow <https://stackoverflow.com/questions/tagged/doctrine-coding-standard>`_
+
+Getting Started
+---------------
+
+The best way to get started is with the :doc:`Introduction <introduction>` section.
+Use the sidebar to browse other documentation for the Doctrine PHP Coding Standards project.

--- a/docs/en/reference/index.rst
+++ b/docs/en/reference/index.rst
@@ -1,0 +1,95 @@
+Introduction
+============
+
+The Doctrine Coding Standard is a set of rules for `PHP_CodeSniffer <https://github.com/squizlabs/PHP_CodeSniffer>`_
+and applies to all Doctrine projects. It is based on `PSR-1 <https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md>`_
+and `PSR-2 <https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md>`_, with some noticeable
+exceptions/differences/extensions.
+
+- Keep the nesting of control structures per method as small as possible
+- Abstract exception class names and exception interface names should be suffixed with ``Exception``
+- Abstract classes should not be prefixed with ``Abstract``
+- Interfaces should not be suffixed with ``Interface``
+- Concrete exception class names should not be suffixed with ``Exception``
+- Align equals (``=``) signs in assignments
+- Add spaces around a concatenation operator ``$foo = 'Hello ' . 'World!';``
+- Add spaces between assignment, control and return statements
+- Add spaces after a negation operator ``if (! $cond)``
+- Add spaces around a colon in return type declaration ``function () : void {}``
+- Add spaces after a type cast ``$foo = (int) '12345';``
+- Use apostrophes for enclosing strings
+- Always use strict comparisons
+- Always add ``declare(strict_types=1)`` at the beginning of a file
+- Always add native types where possible
+- Omit phpDoc for parameters/returns with native types, unless adding description
+- Don't use ``@author``, ``@since`` and similar annotations that duplicate Git information
+- Assignment in condition is not allowed
+- Use parentheses when creating new instances that do not require arguments ``$foo = new Foo()``
+- Use Null Coalesce Operator ``$foo = $bar ?? $baz``
+- Prefer early exit over nesting conditions or using else
+
+For full reference of enforcements, go through ``lib/Doctrine/ruleset.xml`` where each sniff is briefly described.
+
+Installation
+============
+
+You have two possibilities to use the Doctrine Coding Standard with PHP_CodeSniffer in a particular project.
+
+Composer Project Dependency
+---------------------------
+
+You can install the Doctrine Coding Standard as a composer dependency to your particular project.
+Just run the following command to add the Doctrine Coding Standard to your project:
+
+.. code-block:: bash
+
+    $ php composer require --dev doctrine/coding-standard
+
+Then you can use it like:
+
+.. code-block:: bash
+
+    $ ./vendor/bin/phpcs --standard=Doctrine /path/to/some/file/to/sniff.php
+
+You might also do automatic fixes using ``phpcbf``:
+
+.. code-block:: bash
+
+    $ ./vendor/bin/phpcbf --standard=Doctrine /path/to/some/file/to/sniff.php
+
+Composer Global Installation
+----------------------------
+
+You can also install the Doctrine Coding Standard globally:
+
+.. code-block:: bash
+
+    $ composer global require doctrine/coding-standard
+
+Then you can use it like:
+
+.. code-block:: bash
+
+    $ phpcs --standard=Doctrine /path/to/some/file/to/sniff.php
+
+You might also do automatic fixes using ``phpcbf``:
+
+.. code-block:: bash
+
+    $ phpcbf --standard=Doctrine /path/to/some/file/to/sniff.php
+
+Versioning
+==========
+
+This library follows semantic versioning, and additions to the code ruleset
+are only performed in major releases.
+
+Testing
+=======
+
+If you are contributing to the Doctrine Coding Standard and want to test your contribution, you just
+need to execute PHP_CodeSniffer with the tests folder and ensure it matches the expected report:
+
+.. code-block:: bash
+
+    $ ./vendor/bin/phpcs tests/input --report=summary --report-file=phpcs.log; diff tests/expected_report.txt phpcs.log

--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -1,0 +1,4 @@
+.. toctree::
+   :depth: 3
+
+   reference/index


### PR DESCRIPTION
Related to https://github.com/doctrine/doctrine-website/pull/176

Should I change the README.md to look like the other projects and just point to the docs with a few links? That way we don't have to maintain 2 sets of the same information about the project.