### PR TITLE
Mark @api annotation as useful

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -120,7 +120,6 @@
                 name="forbiddenAnnotations"
                 type="array"
                 value="
-                    @api,
                     @author,
                     @category,
                     @copyright,
@@ -258,6 +257,7 @@
                     @after,
                     @afterClass,
                     @AfterMethods,
+                    @api,
                     @Attribute,
                     @Attributes,
                     @before,


### PR DESCRIPTION
Some third party libs use [`@api`](https://docs.phpdoc.org/references/phpdoc/tags/api.html) annotation to generate documentation etc. Not having it in useful annotations IMO might prevent adoption of this CS by other libraries.