### PR TITLE
Require reviews from code owners for CS changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
+/.gitattributes export-ignore
+/.github export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpcs.xml.dist export-ignore
 /tests export-ignore
-.gitattributes export-ignore
-.gitignore export-ignore
-.travis.yml export-ignore
-phpcs.xml.dist export-ignore

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/lib/Doctrine/ruleset.xml @doctrine/coding-standard-approvers


### PR DESCRIPTION
https://blog.github.com/2017-07-06-introducing-code-owners/
https://help.github.com/articles/about-codeowners/

This should make it easier to handle future PRs - reviews will be requested automatically from the @doctrine/coding-standard-approvers team without the need to specify ~10+ people manually every time.

Minimum approvals needed doesn't change. We may additionally enable _Require reviews from Code Owners_.

WDYT?