### PR TITLE
Enable ModernClassNameReference sniff

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -105,6 +105,8 @@
             <property name="fixable" type="boolean" value="true"/>
         </properties>
     </rule>
+    <!-- Require usage of ::class instead of __CLASS__, get_class(), get_class($this), get_called_class() and get_parent_class() -->
+    <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
     <!-- Forbid dead code -->
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
     <!-- Forbid suffix "Abstract" for abstract classes -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -4,6 +4,7 @@ PHP CODE SNIFFER REPORT SUMMARY
 FILE                                                  ERRORS  WARNINGS
 ----------------------------------------------------------------------
 tests/input/array_indentation.php                     10      0
+tests/input/class-references.php                      10      0
 tests/input/concatenation_spacing.php                 24      0
 tests/input/EarlyReturn.php                           5       0
 tests/input/example-class.php                         26      0
@@ -22,9 +23,9 @@ tests/input/test-case.php                             6       0
 tests/input/UnusedVariables.php                       1       0
 tests/input/useless-semicolon.php                     2       0
 ----------------------------------------------------------------------
-A TOTAL OF 163 ERRORS AND 0 WARNINGS WERE FOUND IN 18 FILES
+A TOTAL OF 173 ERRORS AND 0 WARNINGS WERE FOUND IN 19 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 145 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 150 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/class-references.php
+++ b/tests/fixed/class-references.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+class Foo
+{
+}
+
+class Bar extends Foo
+{
+    /**
+     * @return string[]
+     */
+    public function names() : iterable
+    {
+        yield self::class;
+        yield self::class;
+        yield static::class;
+        yield get_class(new stdClass());
+        yield parent::class;
+        yield static::class;
+    }
+}

--- a/tests/input/class-references.php
+++ b/tests/input/class-references.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+class Foo
+{
+}
+
+class Bar extends Foo
+{
+    /**
+     * @return string[]
+     */
+    public function names() : iterable
+    {
+        yield __CLASS__;
+        yield get_class();
+        yield get_class($this);
+        yield get_class(new stdClass());
+        yield get_parent_class();
+        yield get_called_class();
+    }
+}


### PR DESCRIPTION
The following function calls (or legacy constant) are replaced by their respective constant equivalents:

* `__CLASS__` becomes `self::class`
* `get_parent_class()` becomes parent::class
* `get_called_class()` becomes static::class
* `get_class()` becomes self::class
* `get_class($this)` becomes static::class

There are some issues fixed in Slevomat CS 4.7.1-4.7.2, one more edge case will be fixed in 4.7.3.
Should be ok to land already.