### PR TITLE
Enable TraitUseDeclarationSniff & TraitUseSpacingSniff

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -107,6 +107,17 @@
     </rule>
     <!-- Require usage of ::class instead of __CLASS__, get_class(), get_class($this), get_called_class() and get_parent_class() -->
     <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
+    <!-- Forbid uses of multiple traits separated by comma -->
+    <rule ref="SlevomatCodingStandard.Classes.TraitUseDeclaration"/>
+    <!-- Require no spaces before trait use, between trait uses and one space after trait uses -->
+    <rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing">
+        <properties>
+            <property name="linesCountAfterLastUse" value="1"/>
+            <property name="linesCountAfterLastUseWhenLastInClass" value="0"/>
+            <property name="linesCountBeforeFirstUse" value="0"/>
+            <property name="linesCountBetweenUses" value="0"/>
+        </properties>
+    </rule>
     <!-- Forbid dead code -->
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
     <!-- Forbid suffix "Abstract" for abstract classes -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -20,12 +20,13 @@ tests/input/return_type_on_methods.php                17      0
 tests/input/semicolon_spacing.php                     3       0
 tests/input/static-closures.php                       1       0
 tests/input/test-case.php                             6       0
+tests/input/traits-uses.php                           10      0
 tests/input/UnusedVariables.php                       1       0
 tests/input/useless-semicolon.php                     2       0
 ----------------------------------------------------------------------
-A TOTAL OF 173 ERRORS AND 0 WARNINGS WERE FOUND IN 19 FILES
+A TOTAL OF 183 ERRORS AND 0 WARNINGS WERE FOUND IN 20 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 150 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 157 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/traits-uses.php
+++ b/tests/fixed/traits-uses.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TraitUses;
+
+class Foo
+{
+    use T1;
+}
+
+class Bar
+{
+    use T2;
+    use T3;
+    use T4 {
+        x as public;
+    }
+    use T5;
+
+    public function __construct()
+    {
+    }
+}

--- a/tests/input/traits-uses.php
+++ b/tests/input/traits-uses.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TraitUses;
+
+class Foo
+{
+    use T1;
+
+}
+
+class Bar
+{
+    use T2, T3;
+
+    use T4 {
+        x as public;
+    }
+
+    use T5;
+    public function __construct()
+    {
+    }
+}


### PR DESCRIPTION
Two sniffs for `trait` spacing.
We may not use traits directly (now), but our consumers do and having rules for them is essential part of the CS.