### PR TITLE
Validate ruleset against XML schema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,23 @@ script:
   - vendor/bin/phpcs
   - vendor/bin/phpcs $(find tests/input/* | sort) --report=summary --report-file=phpcs.log; diff tests/expected_report.txt phpcs.log
 
+stages:
+  - Validate against schema
+  - Test
+  - Apply fixes
+
 jobs:
   allow_failures:
     - php: nightly
 
   include:
+    - stage: Validate against schema
+      addons:
+        apt:
+          packages:
+            - libxml2-utils
+      script: xmllint --noout --schema vendor/squizlabs/php_codesniffer/phpcs.xsd lib/Doctrine/ruleset.xml
+
     - stage: Apply fixes
       before_script:
         - cp -R tests/input/ tests/input2/

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -102,7 +102,7 @@
     <!-- Require presence of constant visibility -->
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility">
         <properties>
-            <property name="fixable" type="boolean" value="true"/>
+            <property name="fixable" value="true"/>
         </properties>
     </rule>
     <!-- Require usage of ::class instead of __CLASS__, get_class(), get_class($this), get_called_class() and get_parent_class() -->
@@ -199,21 +199,21 @@
     <!-- Forbid using absolute class name references (except global ones) -->
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
         <properties>
-            <property name="allowFallbackGlobalConstants" type="boolean" value="false"/>
-            <property name="allowFallbackGlobalFunctions" type="boolean" value="false"/>
-            <property name="allowFullyQualifiedGlobalClasses" type="boolean" value="false"/>
-            <property name="allowFullyQualifiedGlobalConstants" type="boolean" value="false"/>
-            <property name="allowFullyQualifiedGlobalFunctions" type="boolean" value="false"/>
-            <property name="allowFullyQualifiedNameForCollidingClasses" type="boolean" value="true"/>
-            <property name="allowFullyQualifiedNameForCollidingConstants" type="boolean" value="true"/>
-            <property name="allowFullyQualifiedNameForCollidingFunctions" type="boolean" value="true"/>
-            <property name="searchAnnotations" type="boolean" value="true"/>
+            <property name="allowFallbackGlobalConstants" value="false"/>
+            <property name="allowFallbackGlobalFunctions" value="false"/>
+            <property name="allowFullyQualifiedGlobalClasses" value="false"/>
+            <property name="allowFullyQualifiedGlobalConstants" value="false"/>
+            <property name="allowFullyQualifiedGlobalFunctions" value="false"/>
+            <property name="allowFullyQualifiedNameForCollidingClasses" value="true"/>
+            <property name="allowFullyQualifiedNameForCollidingConstants" value="true"/>
+            <property name="allowFullyQualifiedNameForCollidingFunctions" value="true"/>
+            <property name="searchAnnotations" value="true"/>
         </properties>
     </rule>
     <!-- Forbid unused use statements -->
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
         <properties>
-            <property name="searchAnnotations" type="boolean" value="true"/>
+            <property name="searchAnnotations" value="true"/>
         </properties>
     </rule>
     <!-- Forbid superfluous leading backslash in use statements -->


### PR DESCRIPTION
Validate against XML Schema on CI.

`type="boolean"` has apparently no effect:
https://github.com/squizlabs/PHP_CodeSniffer/blob/3.1.1/src/Ruleset.php#L925-L982
and type conversion is done by magic instead: https://github.com/squizlabs/PHP_CodeSniffer/blob/3.1.1/src/Ruleset.php#L1232-L1253