### PR TITLE
Sniff to forbid increment and decrement operators

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -230,6 +230,8 @@
     </rule>
     <!-- Forbid useless alias for classes, constants and functions -->
     <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
+    <!-- Forbid increment and decrement operators in both flavors -->
+    <rule ref="SlevomatCodingStandard.Operators.DisallowIncrementAndDecrementOperators"/>
     <!-- Require the usage of assignment operators, eg `+=`, `.=` when possible -->
     <rule ref="SlevomatCodingStandard.Operators.RequireCombinedAssignmentOperator"/>
     <!-- Forbid `list(...)` syntax -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -12,6 +12,7 @@ tests/input/EarlyReturn.php                           5       0
 tests/input/example-class.php                         26      0
 tests/input/forbidden-comments.php                    4       0
 tests/input/forbidden-functions.php                   6       0
+tests/input/increment-decrement-operators.php         1       0
 tests/input/LowCaseTypes.php                          2       0
 tests/input/namespaces-spacing.php                    7       0
 tests/input/new_with_parentheses.php                  18      0
@@ -26,7 +27,7 @@ tests/input/traits-uses.php                           10      0
 tests/input/UnusedVariables.php                       1       0
 tests/input/useless-semicolon.php                     2       0
 ----------------------------------------------------------------------
-A TOTAL OF 190 ERRORS AND 0 WARNINGS WERE FOUND IN 22 FILES
+A TOTAL OF 191 ERRORS AND 0 WARNINGS WERE FOUND IN 23 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 163 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------

--- a/tests/fixed/increment-decrement-operators.php
+++ b/tests/fixed/increment-decrement-operators.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+for ($i = 0; $i < 10; $i++) {
+    echo 'foo';
+}

--- a/tests/input/increment-decrement-operators.php
+++ b/tests/input/increment-decrement-operators.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+for ($i = 0; $i < 10; $i++) {
+    echo 'foo';
+}


### PR DESCRIPTION
As suggested in https://github.com/doctrine/coding-standard/pull/83#pullrequestreview-151625922.

Notice that this isn't an auto-fixable Sniff.