### PR TITLE
phpDoc annotation spacing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,13 @@ jobs:
         apt:
           packages:
             - libxml2-utils
-      script: xmllint --noout --schema vendor/squizlabs/php_codesniffer/phpcs.xsd lib/Doctrine/ruleset.xml
+      script:
+        - |
+          if dpkg --compare-versions "$(composer show -n | grep squizlabs/php_codesniffer | tr -s ' ' | cut -d ' ' -f 2)" '>=' "3.3.2"; then
+            xmllint --noout --schema vendor/squizlabs/php_codesniffer/phpcs.xsd lib/Doctrine/ruleset.xml
+          else
+            echo "Validation skipped, PHPCS 3.3.2+ required"
+          fi
 
     - stage: Apply fixes
       before_script:

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,12 @@
     },
     "require": {
         "php": "^7.1",
-        "squizlabs/php_codesniffer": "^3.3.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-        "slevomat/coding-standard": "^4.8.0"
+        "slevomat/coding-standard": "^4.8.0",
+        "squizlabs/php_codesniffer": "^3.3.1"
+    },
+    "config": {
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": "^7.1",
         "squizlabs/php_codesniffer": "^3.3.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-        "slevomat/coding-standard": "^4.7.3"
+        "slevomat/coding-standard": "^4.8.0"
     },
     "extra": {
         "branch-alias": {

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -126,6 +126,33 @@
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
     <!-- Forbid suffix "Interface" for interfaces -->
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
+    <!-- Require specific order of phpDoc annotations with empty newline between specific groups -->
+    <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing">
+        <properties>
+            <property name="linesCountBeforeFirstContent" value="0"/>
+            <property name="linesCountAfterLastContent" value="0"/>
+            <property name="linesCountBetweenDescriptionAndAnnotations" value="1"/>
+            <property name="linesCountBetweenAnnotationsGroups" value="1"/>
+            <property name="annotationsGroups" type="array">
+                <element value="
+                    @internal,
+                    @deprecated,
+                "/>
+                <element value="
+                    @link,
+                    @see,
+                    @uses,
+                "/>
+                <element value="
+                    @ORM\,
+                    @ODM\,
+                "/>
+                <element value="@param"/>
+                <element value="@return"/>
+                <element value="@throws"/>
+            </property>
+        </properties>
+    </rule>
     <!-- Forbid useless annotations - Git and LICENCE file provide more accurate information -->
     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations">
         <properties>

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -8,8 +8,9 @@ tests/input/assignment-operators.php                  4       0
 tests/input/class-references.php                      10      0
 tests/input/concatenation_spacing.php                 24      0
 tests/input/constants-var.php                         3       0
+tests/input/doc-comment-spacing.php                   10      0
 tests/input/EarlyReturn.php                           5       0
-tests/input/example-class.php                         26      0
+tests/input/example-class.php                         28      0
 tests/input/forbidden-comments.php                    4       0
 tests/input/forbidden-functions.php                   6       0
 tests/input/LowCaseTypes.php                          2       0
@@ -26,9 +27,9 @@ tests/input/traits-uses.php                           10      0
 tests/input/UnusedVariables.php                       1       0
 tests/input/useless-semicolon.php                     2       0
 ----------------------------------------------------------------------
-A TOTAL OF 190 ERRORS AND 0 WARNINGS WERE FOUND IN 22 FILES
+A TOTAL OF 202 ERRORS AND 0 WARNINGS WERE FOUND IN 23 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 163 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 173 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/doc-comment-spacing.php
+++ b/tests/fixed/doc-comment-spacing.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test;
+
+use BarException;
+use FooException;
+
+class Test
+{
+    /**
+     * Description
+     */
+    public function a() : void
+    {
+    }
+
+    /**
+     * Description
+     * More Description
+     * Even More Description
+     */
+    public function b() : void
+    {
+    }
+
+    /**
+     * First Paragraph Description
+     *
+     * Second Paragraph Description
+     *
+     * @param int[] $foo
+     *
+     * @throws FooException
+     */
+    public function c(iterable $foo) : void
+    {
+    }
+
+    /**
+     * Description
+     * More Description
+     *
+     * @internal
+     * @deprecated
+     *
+     * @link https://example.com
+     * @see  other
+     * @uses other
+     *
+     * @ORM\Id
+     * @ORM\Column
+     * @ODM\Id
+     * @ODM\Column
+     *
+     * @param int[] $foo
+     * @param int[] $bar
+     *
+     * @return int[]
+     *
+     * @throws FooException
+     * @throws BarException
+     */
+    public function d(iterable $foo, iterable $bar) : iterable
+    {
+    }
+}

--- a/tests/input/doc-comment-spacing.php
+++ b/tests/input/doc-comment-spacing.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test;
+
+use BarException;
+use FooException;
+
+class Test
+{
+    /**
+     *
+     * Description
+     *
+     */
+    public function a() : void
+    {
+    }
+
+    /**
+     * Description
+     * More Description
+     * Even More Description
+     */
+    public function b() : void
+    {
+    }
+
+    /**
+     * First Paragraph Description
+     *
+     * Second Paragraph Description
+     * @throws FooException
+     * @param int[] $foo
+     */
+    public function c(iterable $foo) : void
+    {
+    }
+
+    /**
+     *
+     * Description
+     * More Description
+     * @throws FooException
+     * @deprecated
+     * @param int[] $foo
+     * @uses other
+     * @throws BarException
+     * @return int[]
+     * @ORM\Id
+     * @internal
+     * @link https://example.com
+     * @ODM\Id
+     * @param int[] $bar
+     * @ODM\Column
+     * @ORM\Column
+     * @see  other
+     *
+     */
+    public function d(iterable $foo, iterable $bar) : iterable
+    {
+    }
+}


### PR DESCRIPTION
Sniff to require a newline between between description and tags, a newline between annotation groups and no newline before/after phpDoc content.

Example:
```php
    /**
     * Description
     * More Description
     *
     * @internal
     * @deprecated
     *
     * @link https://example.com
     * @see  other
     * @uses other
     *
     * @ORM\Id
     * @ORM\Column
     * @ODM\Id
     * @ODM\Column
     *
     * @param int[] $foo
     * @param int[] $bar
     *
     * @return int[]
     *
     * @throws FooException
     * @throws BarException
     */
    public function d(iterable $foo, iterable $bar) : iterable
    {
    }
```

This is based on spacing/format used in ORM, does this properly fit other projects (i.e. ODM) too?

Changes in ORM with this enabled are mostly (superfluous newlines) cosmetical: https://github.com/Majkl578/doctrine-orm/commit/68920f1cf50609221fee3f7260cb65b1b2cfc300