### PR TITLE
Enable OptimizedFunctionsWithoutUnpacking sniff

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -259,6 +259,8 @@
     <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
     <!-- Require the usage of assignment operators, eg `+=`, `.=` when possible -->
     <rule ref="SlevomatCodingStandard.Operators.RequireCombinedAssignmentOperator"/>
+    <!-- forbid argument unpacking for functions specialized by PHP VM -->
+    <rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking"/>
     <!-- Forbid `list(...)` syntax -->
     <rule ref="SlevomatCodingStandard.PHP.ShortList"/>
     <!-- Forbid use of longhand cast operators -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -18,6 +18,7 @@ tests/input/namespaces-spacing.php                    7       0
 tests/input/new_with_parentheses.php                  18      0
 tests/input/not_spacing.php                           7       0
 tests/input/null_coalesce_operator.php                3       0
+tests/input/optimized-functions.php                   1       0
 tests/input/return_type_on_closures.php               21      0
 tests/input/return_type_on_methods.php                17      0
 tests/input/semicolon_spacing.php                     3       0
@@ -27,7 +28,7 @@ tests/input/traits-uses.php                           10      0
 tests/input/UnusedVariables.php                       1       0
 tests/input/useless-semicolon.php                     2       0
 ----------------------------------------------------------------------
-A TOTAL OF 202 ERRORS AND 0 WARNINGS WERE FOUND IN 23 FILES
+A TOTAL OF 203 ERRORS AND 0 WARNINGS WERE FOUND IN 24 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 173 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------

--- a/tests/fixed/optimized-functions.php
+++ b/tests/fixed/optimized-functions.php
@@ -1,0 +1,6 @@
+<?php
+
+declare(strict_types=1);
+
+$args = [123, [123], true];
+in_array(...$args);

--- a/tests/input/optimized-functions.php
+++ b/tests/input/optimized-functions.php
@@ -1,0 +1,6 @@
+<?php
+
+declare(strict_types=1);
+
+$args = [123, [123], true];
+in_array(...$args);


### PR DESCRIPTION
From readme:
> PHP optimizes some internal functions into special opcodes on VM level. Such optimization results in much faster execution compared to calling standard function. This only works when these functions are not invoked with argument unpacking (...).
>
> The list of these functions varies across PHP versions, but is the same as functions that must be referenced by their global name (either by \ prefix or using use function), not a fallback name inside namespaced code.