### PR TITLE
Add annotation group violations to expected report

### DIFF
--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -23,14 +23,14 @@ tests/input/return_type_on_closures.php               21      0
 tests/input/return_type_on_methods.php                17      0
 tests/input/semicolon_spacing.php                     3       0
 tests/input/static-closures.php                       1       0
-tests/input/test-case.php                             6       0
+tests/input/test-case.php                             8       0
 tests/input/traits-uses.php                           10      0
 tests/input/UnusedVariables.php                       1       0
 tests/input/useless-semicolon.php                     2       0
 ----------------------------------------------------------------------
-A TOTAL OF 203 ERRORS AND 0 WARNINGS WERE FOUND IN 24 FILES
+A TOTAL OF 205 ERRORS AND 0 WARNINGS WERE FOUND IN 24 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 173 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 175 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/test-case.php
+++ b/tests/fixed/test-case.php
@@ -27,11 +27,10 @@ final class TestCase extends BaseTestCase
     }
 
     /**
-     * @test
-     *
-     * @covers MyClass::test
-     *
      * @uses MyClass::__construct
+     *
+     * @test
+     * @covers MyClass::test
      */
     public function methodShouldDoStuff() : void
     {


### PR DESCRIPTION
The main issue here is that both PHPDocumentor and PHPUnit relies on `@uses` annotation - with different meaning.

I personally wouldn't use `@uses` the way PHPDocumentor defines but I wanted to first have the build fixed before suggesting changes.

BTW this would be my suggestion for annotation groups:

https://github.com/lcobucci/coding-standard/blob/940d248df0a3ff0d3ccfa3ea44c8566313863ce2/src/Lcobucci/ruleset.xml#L33-L52