### PR TITLE
Update the DealerDirect's composer installer dependency to v0.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": "^7.1",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
         "slevomat/coding-standard": "^4.8.0",
         "squizlabs/php_codesniffer": "^3.3.2"
     },


### PR DESCRIPTION
Dealerdirect/phpcodesniffer-composer-installer version [0.5.0](https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.5.0) has been released which contains (among others) a fix for the plugin breaking the composer lifecycle.

