### PR TITLE
Disallow "Class <name>" as class comment

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -176,6 +176,7 @@
                 <element value="~^(?:(?!private|protected|static)\S+ )?(?:con|de)structor\.\z~i"/>
                 <element value="~^Created by \S+\.\z~i"/>
                 <element value="~^\S+ [gs]etter\.\z~i"/>
+                <element value="~^Class \S+\z~i"/>
             </property>
         </properties>
     </rule>

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -11,7 +11,7 @@ tests/input/constants-var.php                         3       0
 tests/input/doc-comment-spacing.php                   10      0
 tests/input/EarlyReturn.php                           5       0
 tests/input/example-class.php                         32      0
-tests/input/forbidden-comments.php                    4       0
+tests/input/forbidden-comments.php                    5       0
 tests/input/forbidden-functions.php                   6       0
 tests/input/LowCaseTypes.php                          2       0
 tests/input/namespaces-spacing.php                    7       0
@@ -28,9 +28,9 @@ tests/input/traits-uses.php                           11      0
 tests/input/UnusedVariables.php                       1       0
 tests/input/useless-semicolon.php                     2       0
 ----------------------------------------------------------------------
-A TOTAL OF 210 ERRORS AND 0 WARNINGS WERE FOUND IN 24 FILES
+A TOTAL OF 211 ERRORS AND 0 WARNINGS WERE FOUND IN 24 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 180 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 181 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/input/forbidden-comments.php
+++ b/tests/input/forbidden-comments.php
@@ -6,6 +6,9 @@ declare(strict_types=1);
 
 namespace Test;
 
+/**
+ * Class Foo
+ */
 class Foo
 {
     /**


### PR DESCRIPTION
`Class Foo` doesn't really add anything of worth to a class doc block, thus should be disallowed in the same fashion as getters/setters and constructors. I believe this is the default template for PhpStorm.