### PR TITLE
Add failing test to reproduce bug with associative arrays

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -375,6 +375,7 @@
         <exclude name="Squiz.Arrays.ArrayDeclaration.ValueNotAligned"/>
         <!-- Checked by SlevomatCodingStandard.Arrays.TrailingArrayComma.MissingTrailingComma -->
         <exclude name="Squiz.Arrays.ArrayDeclaration.NoCommaAfterLast"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.NoComma"/>
     </rule>
     <!-- Forbid class being in a file with different name -->
     <rule ref="Squiz.Classes.ClassFileName"/>

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -24,13 +24,14 @@ tests/input/return_type_on_methods.php                17      0
 tests/input/semicolon_spacing.php                     3       0
 tests/input/static-closures.php                       1       0
 tests/input/test-case.php                             8       0
+tests/input/trailing_comma_on_array.php               1       0
 tests/input/traits-uses.php                           11      0
 tests/input/UnusedVariables.php                       1       0
 tests/input/useless-semicolon.php                     2       0
 ----------------------------------------------------------------------
-A TOTAL OF 215 ERRORS AND 0 WARNINGS WERE FOUND IN 24 FILES
+A TOTAL OF 216 ERRORS AND 0 WARNINGS WERE FOUND IN 25 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 185 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 186 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/trailing_comma_on_array.php
+++ b/tests/fixed/trailing_comma_on_array.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+$array =  [
+    'key1' => 'value',
+    'key2' => 'value',
+];

--- a/tests/input/trailing_comma_on_array.php
+++ b/tests/input/trailing_comma_on_array.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+$array =  [
+    'key1' => 'value',
+    'key2' => 'value'
+];


### PR DESCRIPTION
For some weird reason travis didn't run on https://github.com/doctrine/coding-standard/pull/102, reopening it then...