### PR TITLE
Forbid duplicated variables assignments

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -357,6 +357,8 @@
             <property name="linesCountBeforeClosingBrace" value="0"/>
         </properties>
     </rule>
+    <!-- Forbid duplicated variables assignments -->
+    <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable"/>
     <!-- Forbid useless variables -->
     <rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>
     <!-- Forbid spaces around square brackets -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -9,6 +9,7 @@ tests/input/class-references.php                      10      0
 tests/input/concatenation_spacing.php                 24      0
 tests/input/constants-var.php                         3       0
 tests/input/doc-comment-spacing.php                   10      0
+tests/input/duplicate-assignment-variable.php         1       0
 tests/input/EarlyReturn.php                           5       0
 tests/input/example-class.php                         32      0
 tests/input/forbidden-comments.php                    8       0
@@ -29,7 +30,7 @@ tests/input/traits-uses.php                           11      0
 tests/input/UnusedVariables.php                       1       0
 tests/input/useless-semicolon.php                     2       0
 ----------------------------------------------------------------------
-A TOTAL OF 216 ERRORS AND 0 WARNINGS WERE FOUND IN 25 FILES
+A TOTAL OF 217 ERRORS AND 0 WARNINGS WERE FOUND IN 26 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 186 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------

--- a/tests/fixed/duplicate-assignment-variable.php
+++ b/tests/fixed/duplicate-assignment-variable.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+$foo = $bar = new stdClass();
+
+$baz = $baz = new DateTime();

--- a/tests/input/duplicate-assignment-variable.php
+++ b/tests/input/duplicate-assignment-variable.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+$foo = $bar = new stdClass();
+
+$baz = $baz = new DateTime();


### PR DESCRIPTION
One of the sniffs that came up with Slevomat/CS v4.8.0 and we didn't add.

**This sniff is not autofixable**.