### PR TITLE
Add rule to force simplification of returns

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -203,6 +203,8 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
     <!-- Require usage of null coalesce operator when possible -->
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
+    <!-- Forbid usage of conditions when a simple return can be used -->
+    <rule ref="SlevomatCodingStandard.ControlStructures.UselessConditionWithReturn"/>
     <!-- Forbid useless unreachable catch blocks -->
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
     <!-- Require using Throwable instead of Exception -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -10,7 +10,7 @@ tests/input/concatenation_spacing.php                 24      0
 tests/input/constants-var.php                         3       0
 tests/input/doc-comment-spacing.php                   10      0
 tests/input/duplicate-assignment-variable.php         1       0
-tests/input/EarlyReturn.php                           5       0
+tests/input/EarlyReturn.php                           6       0
 tests/input/example-class.php                         32      0
 tests/input/forbidden-comments.php                    8       0
 tests/input/forbidden-functions.php                   6       0
@@ -29,10 +29,11 @@ tests/input/trailing_comma_on_array.php               1       0
 tests/input/traits-uses.php                           11      0
 tests/input/UnusedVariables.php                       1       0
 tests/input/useless-semicolon.php                     2       0
+tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 217 ERRORS AND 0 WARNINGS WERE FOUND IN 26 FILES
+A TOTAL OF 238 ERRORS AND 0 WARNINGS WERE FOUND IN 27 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 186 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 207 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/EarlyReturn.php
+++ b/tests/fixed/EarlyReturn.php
@@ -8,11 +8,7 @@ class EarlyReturn
 {
     public function bar() : bool
     {
-        if ($bar === 'bar') {
-            return true;
-        }
-
-        return false;
+        return $bar === 'bar';
     }
 
     public function foo() : ?string
@@ -43,10 +39,6 @@ class EarlyReturn
             return false;
         }
 
-        if (false === false) {
-            return true;
-        }
-
-        return true;
+        return false === false;
     }
 }

--- a/tests/fixed/UselessConditions.php
+++ b/tests/fixed/UselessConditions.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Conditions;
+
+use function count;
+use function strpos;
+
+class UselessConditions
+{
+    public function uselessCondition() : bool
+    {
+        return $foo === 'foo';
+    }
+
+    public function uselessIfCondition() : bool
+    {
+        return $bar === 'bar';
+    }
+
+    public function uselessNegativeCondition() : bool
+    {
+        return $foo === 'foo';
+    }
+
+    public function uselessIfNegativeCondition() : bool
+    {
+        return $bar !== 'bar';
+    }
+
+    public function unecessaryIfMethodForEarlyReturn() : bool
+    {
+        if ($bar === 'bar') {
+            return false;
+        }
+
+        if ($foo === 'foo') {
+            return false;
+        }
+
+        return $baz !== 'baz';
+    }
+
+    public function uselessIfConditionWithParameter(bool $bool) : bool
+    {
+        return ! $bool;
+    }
+
+    public function uselessIfConditionWithBoolMethod() : bool
+    {
+        return ! $this->isTrue();
+    }
+
+    public function uselessIfConditionWithComplexIf() : bool
+    {
+        return $bar === 'bar' && $foo === 'foo' && $baz !== 'quox';
+    }
+
+    public function uselessIfConditionWithEvenMoreComplexIf() : bool
+    {
+        return $bar === 'bar' || $foo === 'foo' || $baz !== 'quox';
+    }
+
+    public function uselessIfConditionWithComplexCondition() : bool
+    {
+        return $bar !== 'bar' && $foo !== 'foo' && $baz === 'quox';
+    }
+
+    public function uselessIfConditionWithTernary() : bool
+    {
+        if ($this->isTrue()) {
+            return $this->isTrulyTrue();
+        }
+
+        return false;
+    }
+
+    public function necessaryIfConditionWithMethodCall() : bool
+    {
+        if ($this->shouldBeQueued()) {
+            $this->queue();
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function nullShouldNotBeTreatedAsFalse() : ?bool
+    {
+        if (! $this->isAdmin) {
+            return null;
+        }
+
+        return true;
+    }
+
+    public function uselessTernary() : bool
+    {
+        return $foo !== 'bar';
+    }
+
+    public function uselessTernaryWithParameter(bool $condition) : bool
+    {
+        return $condition;
+    }
+
+    public function uselessTernaryWithMethod() : bool
+    {
+        return $this->isFalse();
+    }
+
+    /**
+     * @param string[] $words
+     */
+    public function uselessTernaryCheck(array $words) : bool
+    {
+        return count($words) < 1;
+    }
+
+    public function necessaryTernary() : int
+    {
+        return strpos('foo', 'This is foo and bar') !== false ? 1 : 0;
+    }
+}

--- a/tests/input/UselessConditions.php
+++ b/tests/input/UselessConditions.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Conditions;
+
+use function count;
+use function strpos;
+
+class UselessConditions
+{
+    public function uselessCondition() : bool
+    {
+        if ($foo === 'foo') {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public function uselessIfCondition() : bool
+    {
+        if ($bar === 'bar') {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function uselessNegativeCondition() : bool
+    {
+        if ($foo !== 'foo') {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public function uselessIfNegativeCondition() : bool
+    {
+        if ($bar === 'bar') {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function unecessaryIfMethodForEarlyReturn() : bool
+    {
+        if ($bar === 'bar') {
+            return false;
+        }
+
+        if ($foo === 'foo') {
+            return false;
+        }
+
+        if ($baz === 'baz') {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function uselessIfConditionWithParameter(bool $bool) : bool
+    {
+        if ($bool) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function uselessIfConditionWithBoolMethod() : bool
+    {
+        if ($this->isTrue()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function uselessIfConditionWithComplexIf() : bool
+    {
+        if ($bar === 'bar' && $foo === 'foo' && $baz !== 'quox') {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public function uselessIfConditionWithEvenMoreComplexIf() : bool
+    {
+        if ($bar === 'bar' || $foo === 'foo' || $baz !== 'quox') {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public function uselessIfConditionWithComplexCondition() : bool
+    {
+        if ($bar === 'bar' || $foo === 'foo' || $baz !== 'quox') {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function uselessIfConditionWithTernary() : bool
+    {
+        if ($this->isTrue()) {
+            return $this->isTrulyTrue() ? true : false;
+        } else {
+            return false;
+        }
+    }
+
+    public function necessaryIfConditionWithMethodCall() : bool
+    {
+        if ($this->shouldBeQueued()) {
+            $this->queue();
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function nullShouldNotBeTreatedAsFalse() : ?bool
+    {
+        if (! $this->isAdmin) {
+            return null;
+        }
+
+        return true;
+    }
+
+    public function uselessTernary() : bool
+    {
+        return $foo !== 'bar' ? true : false;
+    }
+
+    public function uselessTernaryWithParameter(bool $condition) : bool
+    {
+        return $condition ? true : false;
+    }
+
+    public function uselessTernaryWithMethod() : bool
+    {
+        return $this->isFalse() ? true : false;
+    }
+
+    /**
+     * @param string[] $words
+     */
+    public function uselessTernaryCheck(array $words) : bool
+    {
+        return count($words) >= 1 ? false : true;
+    }
+
+    public function necessaryTernary() : int
+    {
+        return strpos('foo', 'This is foo and bar') !== false ? 1 : 0;
+    }
+}


### PR DESCRIPTION
This PR adds a Sniff to automate a couple of refactoring I've been doing across Doctrine's repositories.

Note that this PR will affect structs that have early returns, as tested under the method `unecessaryIfMethodForEarlyReturn`.