### PR TITLE
Remove MultipleStatementAlignment

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -31,12 +31,6 @@
     <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
     <!-- Forbid inline HTML in PHP code -->
     <rule ref="Generic.Files.InlineHTML"/>
-    <!-- Align corresponding assignment statement tokens -->
-    <rule ref="Generic.Formatting.MultipleStatementAlignment">
-        <properties>
-            <property name="error" value="true"/>
-        </properties>
-    </rule>
     <!-- Force whitespace after a type cast -->
     <rule ref="Generic.Formatting.SpaceAfterCast">
         <properties>


### PR DESCRIPTION
We don't align `=>` in arrays and I think we shouldn't do that for assignments as well. It's creating a lot of [noise in the diff](https://github.com/doctrine/mongodb-odm/pull/1946/files#diff-ae2c9f4b58c612dce08a0f60ff683aecL457) and produces [weirdly looking code when assignment to an array is nearby](https://github.com/doctrine/mongodb-odm/pull/1946/files#diff-ae2c9f4b58c612dce08a0f60ff683aecR1640). I'm putting this for a vote for 6.0.0, if we come to conclusion we want to remove this rule I'll fix failing tests