### PR TITLE
Enable SpreadOperatorSpacing sniff

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -270,6 +270,8 @@
     <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
     <!-- Require the usage of assignment operators, eg `+=`, `.=` when possible -->
     <rule ref="SlevomatCodingStandard.Operators.RequireCombinedAssignmentOperator"/>
+    <!-- Require no spacing after spread operator -->
+    <rule ref="SlevomatCodingStandard.Operators.SpreadOperatorSpacing"/>
     <!-- forbid argument unpacking for functions specialized by PHP VM -->
     <rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking"/>
     <!-- Forbid `list(...)` syntax -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -23,6 +23,7 @@ tests/input/optimized-functions.php                   1       0
 tests/input/return_type_on_closures.php               21      0
 tests/input/return_type_on_methods.php                17      0
 tests/input/semicolon_spacing.php                     3       0
+tests/input/spread-operator.php                       6       0
 tests/input/static-closures.php                       1       0
 tests/input/test-case.php                             8       0
 tests/input/trailing_comma_on_array.php               1       0
@@ -31,9 +32,9 @@ tests/input/UnusedVariables.php                       1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 238 ERRORS AND 0 WARNINGS WERE FOUND IN 27 FILES
+A TOTAL OF 244 ERRORS AND 0 WARNINGS WERE FOUND IN 28 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 202 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 208 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/spread-operator.php
+++ b/tests/fixed/spread-operator.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+static function (...$x) : void {
+}
+static function (int ...$x) : void {
+}
+static function ($x, ...$y) : void {
+}
+static function (int $x, int ...$y) : void {
+}
+
+foo(...$x);
+foo($x, ...$y);

--- a/tests/input/spread-operator.php
+++ b/tests/input/spread-operator.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+static function (... $x) : void {
+}
+static function (int ... $x) : void {
+}
+static function ($x, ... $y) : void {
+}
+static function (int $x, int ... $y) : void {
+}
+
+foo(... $x);
+foo($x, ... $y);


### PR DESCRIPTION
Simple sniff to check that ellipsis are not followed by spacing - see tests.