### PR TITLE
Forbid LSB for constants

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -106,6 +106,8 @@
             <property name="fixable" value="true"/>
         </properties>
     </rule>
+    <!-- Forbid LSB for constants (static::FOO) -->
+    <rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants"/>
     <!-- Forbid empty lines around type declarations -->
     <rule ref="SlevomatCodingStandard.Classes.EmptyLinesAroundClassBraces">
         <properties>

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -7,6 +7,7 @@ tests/input/array_indentation.php                     10      0
 tests/input/assignment-operators.php                  4       0
 tests/input/class-references.php                      10      0
 tests/input/concatenation_spacing.php                 24      0
+tests/input/constants-no-lsb.php                      2       0
 tests/input/constants-var.php                         3       0
 tests/input/doc-comment-spacing.php                   10      0
 tests/input/duplicate-assignment-variable.php         1       0
@@ -32,9 +33,9 @@ tests/input/UnusedVariables.php                       1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 244 ERRORS AND 0 WARNINGS WERE FOUND IN 28 FILES
+A TOTAL OF 246 ERRORS AND 0 WARNINGS WERE FOUND IN 29 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 208 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 209 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/constants-no-lsb.php
+++ b/tests/fixed/constants-no-lsb.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test;
+
+class ConstantLsb
+{
+    public const A = 123;
+
+    public function __construct()
+    {
+        echo self::A;
+    }
+}

--- a/tests/input/constants-no-lsb.php
+++ b/tests/input/constants-no-lsb.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test;
+
+class ConstantLsb
+{
+    public const A = 123;
+
+    public function __construct()
+    {
+        echo static::A;
+    }
+}


### PR DESCRIPTION
Constants are not meant to be overriden, using such behaviour asks for troubles and abstract method should be used instead.