### PR TITLE
Disallow continue without operand targetting switch

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -202,6 +202,8 @@
     <rule ref="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment"/>
     <!-- Forbid assignments in conditions -->
     <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
+    <!-- Forbid `continue;` without integer operand inside switch (deprecated in PHP 7.3) -->
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch"/>
     <!-- Forbid fancy yoda conditions -->
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
     <!-- Require usage of early exit -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -9,6 +9,7 @@ tests/input/class-references.php                      10      0
 tests/input/concatenation_spacing.php                 24      0
 tests/input/constants-no-lsb.php                      2       0
 tests/input/constants-var.php                         3       0
+tests/input/continue-in-switch.php                    1       0
 tests/input/doc-comment-spacing.php                   10      0
 tests/input/duplicate-assignment-variable.php         1       0
 tests/input/EarlyReturn.php                           6       0
@@ -34,9 +35,9 @@ tests/input/UnusedVariables.php                       1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 257 ERRORS AND 0 WARNINGS WERE FOUND IN 30 FILES
+A TOTAL OF 258 ERRORS AND 0 WARNINGS WERE FOUND IN 31 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 209 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 210 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/continue-in-switch.php
+++ b/tests/fixed/continue-in-switch.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+foreach ([1, 2, 3] as $i) {
+    switch ($i) {
+        case 1:
+            break;
+        case 2:
+            continue 2;
+        case 3:
+            break;
+    }
+
+    foo();
+}

--- a/tests/input/continue-in-switch.php
+++ b/tests/input/continue-in-switch.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+foreach ([1, 2, 3] as $i) {
+    switch ($i) {
+        case 1:
+            continue;
+        case 2:
+            continue 2;
+        case 3:
+            break;
+    }
+
+    foo();
+}


### PR DESCRIPTION
This is deprecated since PHP 7.3.