### PR TITLE
implement new sniff to force spaces after `=`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ install: travis_retry composer update --prefer-dist
 script:
   - vendor/bin/phpcs
   - vendor/bin/phpcs $(find tests/input/* | sort) --report=summary --report-file=phpcs.log; diff tests/expected_report.txt phpcs.log
+  - vendor/bin/phpstan analyse
+  - vendor/bin/phpunit
 
 stages:
   - Validate against schema

--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,17 @@
         "branch-alias": {
             "dev-master": "7.0.x-dev"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7.5",
+        "phpstan/phpstan": "^0.11",
+        "phpstan/phpstan-phpunit": "^0.11",
+        "phpstan/phpstan-deprecation-rules": "^0.11",
+        "phpstan/phpstan-strict-rules": "^0.11"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Doctrine\\": "tests/Doctrine"
+        }
     }
 }

--- a/docs/en/reference/index.rst
+++ b/docs/en/reference/index.rst
@@ -132,3 +132,15 @@ need to execute PHP_CodeSniffer with the tests folder and ensure it matches the 
 .. code-block:: bash
 
     $ ./vendor/bin/phpcs tests/input --report=summary --report-file=phpcs.log; diff tests/expected_report.txt phpcs.log
+
+If you have implemented custom sniff also run PHPStan and PHPUnit.
+The PHPUnit version to be used is the one installed as a dev- dependency
+via composer (same rules are for PHPStan):
+
+.. code-block:: console
+
+   $ ./vendor/bin/phpunit
+   $ ./vendor/bin/phpstan analyse
+
+Accepted coverage for new contributions is 80%. There must not be any errors shown by PHPStan.
+Any contribution not satisfying this requirement won’t be merged.

--- a/lib/Doctrine/Sniffs/Arrays/OperatorSpacingAfterSniff.php
+++ b/lib/Doctrine/Sniffs/Arrays/OperatorSpacingAfterSniff.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Sniffs\Arrays;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\OperatorSpacingSniff as SquizOperatorSpacingSniff;
+use const T_EQUAL;
+use const T_INLINE_ELSE;
+use const T_INLINE_THEN;
+use const T_WHITESPACE;
+use function strlen;
+
+final class OperatorSpacingAfterSniff extends SquizOperatorSpacingSniff
+{
+    private const MESSAGE_AFTER = 'Expected exactly 1 space after "%s"; %d found';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function register() : array
+    {
+        return [T_EQUAL];
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param int $pointer
+     */
+    public function process(File $phpcsFile, $pointer) : void
+    {
+        if (! $this->isOperator($phpcsFile, $pointer)) {
+            return;
+        }
+
+        $this->ensureOneSpaceAfterOperator($phpcsFile, $pointer, $phpcsFile->getTokens());
+    }
+
+    /**
+     * @param mixed[] $tokens
+     */
+    private function ensureOneSpaceAfterOperator(File $file, int $pointer, array $tokens) : void
+    {
+        if (! $this->shouldValidateAfter($pointer, $tokens)) {
+            return;
+        }
+
+        $numberOfSpaces = $this->numberOfSpaces($tokens[$pointer + 1]);
+
+        if ($numberOfSpaces === 1 || ! $this->recordErrorAfter($file, $pointer, $tokens[$pointer], $numberOfSpaces)) {
+            return;
+        }
+
+        if ($numberOfSpaces === 0) {
+            $file->fixer->addContent($pointer, ' ');
+
+            return;
+        }
+
+        $file->fixer->replaceToken($pointer + 1, ' ');
+    }
+
+    /**
+     * @param mixed[] $tokens
+     */
+    private function shouldValidateAfter(int $pointer, array $tokens) : bool
+    {
+        if (! isset($tokens[$pointer + 1])) {
+            return false;
+        }
+
+        return $tokens[$pointer]['code'] !== T_INLINE_THEN || $tokens[$pointer + 1]['code'] !== T_INLINE_ELSE;
+    }
+
+    /**
+     * @param mixed[] $token
+     */
+    private function recordErrorAfter(File $file, int $pointer, array $token, int $numberOfSpaces) : bool
+    {
+        return $file->addFixableError(
+            self::MESSAGE_AFTER,
+            $pointer,
+            'NoSpaceAfterAssigment',
+            [$token['content'], $numberOfSpaces]
+        );
+    }
+
+    /**
+     * @param mixed[] $token
+     */
+    private function numberOfSpaces(array $token) : int
+    {
+        if ($token['code'] !== T_WHITESPACE) {
+            return 0;
+        }
+
+        return strlen($token['content']);
+    }
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,5 +15,8 @@
 
     <rule ref="Doctrine"/>
 
-    <file>lib</file>
+    <file>lib/</file>
+    <file>tests/Doctrine/</file>
+
+    <exclude-pattern>tests/**/data/*</exclude-pattern>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,17 @@
+parameters:
+        level: 7
+        paths:
+        - "%currentWorkingDirectory%/lib/"
+        - "%currentWorkingDirectory%/tests/Doctrine"
+        autoload_files:
+        - "%currentWorkingDirectory%/tests/bootstrap.php"
+        ignoreErrors:
+                -
+                        message: '#Method [a-zA-Z0-9\\_]+::process\(\) has parameter \$pointer with no typehint specified#'
+                        path: %currentWorkingDirectory%/lib/Doctrine/Sniffs/*
+
+includes:
+        - vendor/phpstan/phpstan-deprecation-rules/rules.neon
+        - vendor/phpstan/phpstan-phpunit/extension.neon
+        - vendor/phpstan/phpstan-phpunit/rules.neon
+        - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         colors="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         bootstrap="tests/bootstrap.php"
+>
+
+    <testsuite name="Doctrine Coding Standard Test Suite">
+        <directory suffix="Test.php">tests/Doctrine/</directory>
+    </testsuite>
+</phpunit>

--- a/tests/Doctrine/Sniffs/Arrays/OperatorSpacingAfterSniffTest.php
+++ b/tests/Doctrine/Sniffs/Arrays/OperatorSpacingAfterSniffTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Sniffs\Arrays;
+
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+final class OperatorSpacingAfterSniffTest extends TestCase
+{
+    public function testNoErrors() : void
+    {
+        $phpcsFile = self::checkFile(__DIR__ . '/data/operatorSpacingAfterSniff.noErrors.php');
+        self::assertNoSniffErrorInFile($phpcsFile);
+    }
+
+    public function testErrors() : void
+    {
+        $phpcsFile = self::checkFile(__DIR__ . '/data/operatorSpacingAfterSniff.errors.php');
+
+        self::assertSame(1, $phpcsFile->getErrorCount());
+
+        self::assertSniffError($phpcsFile, 4, 'NoSpaceAfterAssigment');
+    }
+}

--- a/tests/Doctrine/Sniffs/Arrays/data/operatorSpacingAfterSniff.errors.php
+++ b/tests/Doctrine/Sniffs/Arrays/data/operatorSpacingAfterSniff.errors.php
@@ -1,0 +1,11 @@
+<?php
+
+
+$arrayWithMultipleSpacesAfterAssigmentOperator =                       [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+];

--- a/tests/Doctrine/Sniffs/Arrays/data/operatorSpacingAfterSniff.noErrors.php
+++ b/tests/Doctrine/Sniffs/Arrays/data/operatorSpacingAfterSniff.noErrors.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+$array = [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+];
+
+$arrayWithMultipleSpacesBeforeAssigmentOperator                       = [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+];

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types = 1);
+
+error_reporting(E_ALL);
+
+require __DIR__.'/../vendor/autoload.php';
+require __DIR__.'/../vendor/squizlabs/php_codesniffer/tests/bootstrap.php';

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -3,7 +3,7 @@ PHP CODE SNIFFER REPORT SUMMARY
 ----------------------------------------------------------------------
 FILE                                                  ERRORS  WARNINGS
 ----------------------------------------------------------------------
-tests/input/array_indentation.php                     10      0
+tests/input/array_indentation.php                     11      0
 tests/input/assignment-operators.php                  4       0
 tests/input/class-references.php                      10      0
 tests/input/concatenation_spacing.php                 24      0
@@ -35,9 +35,9 @@ tests/input/UnusedVariables.php                       1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 264 ERRORS AND 0 WARNINGS WERE FOUND IN 31 FILES
+A TOTAL OF 265 ERRORS AND 0 WARNINGS WERE FOUND IN 31 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 216 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 217 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/array_indentation.php
+++ b/tests/fixed/array_indentation.php
@@ -22,3 +22,12 @@ $multiArray = [
         9,
     ],
 ];
+
+$arrayWithMultipleSpacesAfterAssigmentOperator = [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+];

--- a/tests/fixed/trailing_comma_on_array.php
+++ b/tests/fixed/trailing_comma_on_array.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-$array =  [
+$array = [
     'key1' => 'value',
     'key2' => 'value',
 ];

--- a/tests/input/array_indentation.php
+++ b/tests/input/array_indentation.php
@@ -22,3 +22,12 @@ $multiArray = [
          9,
     ],
 ];
+
+$arrayWithMultipleSpacesAfterAssigmentOperator =                       [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+];

--- a/tests/input/trailing_comma_on_array.php
+++ b/tests/input/trailing_comma_on_array.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-$array =  [
+$array = [
     'key1' => 'value',
     'key2' => 'value'
 ];


### PR DESCRIPTION
I haven't yet found the rule that will help with that (since `MultipleStatementAlignmentSniff` doesn't work here)

This PR/issue comes from this #103 (comment)

This is a copy of https://github.com/doctrine/coding-standard/pull/117 as per https://github.com/doctrine/coding-standard/pull/117#issuecomment-488038466