### PR TITLE
Consider removing UselessOverridingMethod

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -27,8 +27,6 @@
     </rule>
     <!-- Forbid final methods in final classes -->
     <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
-    <!-- Forbid useless empty method overrides -->
-    <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
     <!-- Forbid inline HTML in PHP code -->
     <rule ref="Generic.Files.InlineHTML"/>
     <!-- Align corresponding assignment statement tokens -->


### PR DESCRIPTION
UselessOverridingMethod has known issues and is recommended to not be used (see https://github.com/squizlabs/PHP_CodeSniffer/issues/519)

Another style of issue would be auto-wiring. for example

```
interface generic {}

class specific1 implements generic {}

class specific2 implements generic {}



abstract class test
{
  public function __construct(generic $variable) {
    $this->variable = $variable;
  }
}

class a extends test
{
  public function __construct(specific1 $variable) {
      return parent::__construct($variable);
  }
}

class b extends test
{
  public function __construct(specific2 $variable) {
      return parent::__construct($variable);
  }
}
```


The specific versions (a and b) are required to be set like this for auto wiring to work.  This also triggers the useless override. which would be true if auto wiring was not used as you could make the object directly.