### PR TITLE
Drop PHP 7.1, add 7.4 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4snapshot
   - nightly
 
 cache:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
        }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
         "slevomat/coding-standard": "dev-master#63a8186b129ee96d1277e68c80cf87c8cdb356d1",
         "squizlabs/php_codesniffer": "^3.4.0"


### PR DESCRIPTION
Build doesn't run anymore on 7.1

>   Problem 1
    - Installation request for slevomat/coding-standard dev-master#63a8186b129ee96d1277e68c80cf87c8cdb356d1 -> satisfiable by slevomat/coding-standard[dev-master].
    - slevomat/coding-standard dev-master requires php ^7.2 -> your PHP version (7.1.27) does not satisfy that requirement.