### PR TITLE
Camel case vars

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -410,6 +410,10 @@
     </rule>
     <!-- Forbid global functions -->
     <rule ref="Squiz.Functions.GlobalFunction"/>
+    <!-- Force camelCase variables -->
+    <rule ref="Squiz.NamingConventions.ValidVariableName">
+        <exclude name="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore" />
+    </rule>
     <!-- Forbid `AND` and `OR`, require `&&` and `||` -->
     <rule ref="Squiz.Operators.ValidLogicalOperators"/>
     <!-- Forbid `global` -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -18,6 +18,7 @@ tests/input/forbidden-functions.php                   6       0
 tests/input/inline_type_hint_assertions.php           6       0
 tests/input/LowCaseTypes.php                          2       0
 tests/input/namespaces-spacing.php                    7       0
+tests/input/NamingCamelCase.php                       7       0
 tests/input/new_with_parentheses.php                  18      0
 tests/input/not_spacing.php                           8       0
 tests/input/null_coalesce_operator.php                3       0
@@ -35,7 +36,7 @@ tests/input/UnusedVariables.php                       1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 264 ERRORS AND 0 WARNINGS WERE FOUND IN 31 FILES
+A TOTAL OF 271 ERRORS AND 0 WARNINGS WERE FOUND IN 32 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 216 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------

--- a/tests/fixed/NamingCamelCase.php
+++ b/tests/fixed/NamingCamelCase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Example;
+
+class NamingCamelCase
+{
+    /** @var mixed */
+    public $A;
+
+    /** @var mixed */
+    protected $B;
+
+    /** @var mixed */
+    private $C;
+
+    public function fcn(string $A) : void
+    {
+        $Test = $A;
+    }
+}

--- a/tests/input/NamingCamelCase.php
+++ b/tests/input/NamingCamelCase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Example;
+
+class NamingCamelCase
+{
+    /** @var mixed */
+    public $A;
+
+    /** @var mixed */
+    protected $B;
+
+    /** @var mixed */
+    private $C;
+
+    public function fcn(string $A) : void
+    {
+        $Test = $A;
+    }
+}


### PR DESCRIPTION
I noticed there was no sniff enabled to force camelCase variable names. 

I cannot create issue to ask so I created this PR. Is there a reason for absence of such rule or is this PR actually viable? Eg. methodNames() or ClassNames are required to be camelCased.