### PR TITLE
Lock PHPCS in its latest commit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": "^7.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
         "slevomat/coding-standard": "dev-master#63a8186b129ee96d1277e68c80cf87c8cdb356d1",
-        "squizlabs/php_codesniffer": "^3.4.0"
+        "squizlabs/php_codesniffer": "dev-master#a7403540490022691559380cfc8bfc1342890998"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
To fix the PHP 7.4 compatibility issues.

This shall be solved as soon as they release v3.5.0.