### PR TITLE
Drop psr12Compatible false, default is true

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -234,11 +234,7 @@
     <!-- Forbid unused variables passed to closures via `use` -->
     <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
     <!-- Require use statements to be alphabetically sorted -->
-    <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">
-        <properties>
-            <property name="psr12Compatible" value="false"/>
-        </properties>
-    </rule>
+    <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
     <!-- Forbid fancy group uses -->
     <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
     <!-- Forbid multiple use statements on same line -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -33,12 +33,13 @@ tests/input/test-case.php                             8       0
 tests/input/trailing_comma_on_array.php               1       0
 tests/input/traits-uses.php                           11      0
 tests/input/UnusedVariables.php                       1       0
+tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 271 ERRORS AND 0 WARNINGS WERE FOUND IN 32 FILES
+A TOTAL OF 272 ERRORS AND 0 WARNINGS WERE FOUND IN 33 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 216 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 217 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/example-class.php
+++ b/tests/fixed/example-class.php
@@ -9,12 +9,12 @@ use Doctrine\Sniffs\Spacing\ControlStructureSniff;
 use Fancy\TestCase;
 use InvalidArgumentException;
 use IteratorAggregate;
-use const PHP_MINOR_VERSION;
-use const PHP_RELEASE_VERSION as PHP_PATCH_VERSION;
-use const PHP_VERSION;
 use function assert;
 use function strlen as stringLength;
 use function substr;
+use const PHP_MINOR_VERSION;
+use const PHP_RELEASE_VERSION as PHP_PATCH_VERSION;
+use const PHP_VERSION;
 
 /**
  * Description

--- a/tests/fixed/namespaces-spacing.php
+++ b/tests/fixed/namespaces-spacing.php
@@ -7,9 +7,9 @@ namespace Foo;
 use DateInterval;
 use DateTimeImmutable;
 use DateTimeZone;
-use const DATE_RFC3339;
 use function strrev;
 use function time;
+use const DATE_RFC3339;
 
 strrev(
     (new DateTimeImmutable('@' . time(), new DateTimeZone('UTC')))

--- a/tests/fixed/use-ordering.php
+++ b/tests/fixed/use-ordering.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Foo;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use function sprintf;
+use const PHP_EOL;
+
+echo sprintf('Current date and time is %s', (new DateTimeImmutable())->format(DateTimeInterface::ATOM)) . PHP_EOL;

--- a/tests/input/namespaces-spacing.php
+++ b/tests/input/namespaces-spacing.php
@@ -6,10 +6,10 @@ use DateInterval;
 use DateTimeImmutable;
 use DateTimeZone;
 
-use const DATE_RFC3339;
-
 use function strrev;
 use function time;
+
+use const DATE_RFC3339;
 strrev(
     (new DateTimeImmutable('@' . time(), new DateTimeZone('UTC')))
         ->sub(new DateInterval('P1D'))

--- a/tests/input/use-ordering.php
+++ b/tests/input/use-ordering.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Foo;
+
+use function sprintf;
+use DateTimeImmutable;
+use const PHP_EOL;
+use DateTimeInterface;
+
+echo sprintf('Current date and time is %s', (new DateTimeImmutable())->format(DateTimeInterface::ATOM)) . PHP_EOL;


### PR DESCRIPTION
[PSR-12 is accepted](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-12-extended-coding-style-guide.md) so I was thinking it's time to default to it and to defaults in Jetbrains' IDEs. WDYT?