### PR TITLE
Update to PHPCS v3.5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": "^7.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
         "slevomat/coding-standard": "dev-master#63a8186b129ee96d1277e68c80cf87c8cdb356d1",
-        "squizlabs/php_codesniffer": "dev-master#a7403540490022691559380cfc8bfc1342890998"
+        "squizlabs/php_codesniffer": "^3.5.0"
     },
     "config": {
         "sort-packages": true

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -12,6 +12,8 @@
         <exclude name="PSR2.Namespaces.UseDeclaration.SpaceAfterLastUse"/>
         <!-- checked by SlevomatCodingStandard.Namespaces.NamespaceSpacing -->
         <exclude name="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter"/>
+        <!-- checked by SlevomatCodingStandard.Operators.SpreadOperatorSpacing -->
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterVariadic"/>
     </rule>
 
     <!-- Force array element indentation with 4 spaces -->


### PR DESCRIPTION
The only sniff that affects us is `Squiz.Functions.FunctionDeclarationArgumentSpacing`, that now checks space after a variadic operator. But, since we have `SlevomatCodingStandard.Operators.SpreadOperatorSpacing` doing that on a larger scale, we can ignore that one. Changelog:

> - `Squiz.Functions.FunctionDeclarationArgumentSpacing` now checks for no space after a variadic operator
    - If you don't want this new behaviour, exclude the `SpacingAfterVariadic` error message in a `ruleset.xml` file

This PR will allow us to adopt PSR-12 in the future.