### PR TITLE
Add custom sniffs to address spacing of operators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor/
+.phpunit.result.cache
 phpcs.xml
 composer.lock
 tests/input2

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install: travis_retry composer update --prefer-dist
 script:
   - vendor/bin/phpcs
   - vendor/bin/phpcs $(find tests/input/* | sort) --report=summary --report-file=phpcs.log; diff tests/expected_report.txt phpcs.log
+  - vendor/bin/phpunit
 
 stages:
   - Validate against schema

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,19 @@
            "Doctrine\\Sniffs\\": "lib/Doctrine/Sniffs"
        }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Doctrine\\Tests\\": "tests/"
+        }
+    },
     "require": {
         "php": "^7.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
         "slevomat/coding-standard": "dev-master#63a8186b129ee96d1277e68c80cf87c8cdb356d1",
         "squizlabs/php_codesniffer": "^3.5.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^8.1"
     },
     "config": {
         "sort-packages": true

--- a/lib/Doctrine/Sniffs/Operators/NegationOperatorSpacingSniff.php
+++ b/lib/Doctrine/Sniffs/Operators/NegationOperatorSpacingSniff.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Sniffs\Operators;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+use function in_array;
+use function strlen;
+use const T_CLOSE_PARENTHESIS;
+use const T_CLOSE_SHORT_ARRAY;
+use const T_CLOSE_SQUARE_BRACKET;
+use const T_CONSTANT_ENCAPSED_STRING;
+use const T_DNUMBER;
+use const T_ENCAPSED_AND_WHITESPACE;
+use const T_LNUMBER;
+use const T_MINUS;
+use const T_NUM_STRING;
+use const T_STRING;
+use const T_VARIABLE;
+use const T_WHITESPACE;
+
+final class NegationOperatorSpacingSniff implements Sniff
+{
+    public const CODE_INVALID_SPACE_AFTER_MINUS = 'InvalidSpaceAfterMinus';
+
+    /** @var bool */
+    public $requireSpace = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function register() : array
+    {
+        return [T_MINUS];
+    }
+
+    /**
+     * @param int $pointer
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+     */
+    public function process(File $file, $pointer) : void
+    {
+        $tokens = $file->getTokens();
+
+        $previousEffective = TokenHelper::findPreviousEffective($file, $pointer - 1);
+
+        $possibleOperandTypes = [
+            T_CONSTANT_ENCAPSED_STRING,
+            T_CLOSE_PARENTHESIS,
+            T_CLOSE_SHORT_ARRAY,
+            T_CLOSE_SQUARE_BRACKET,
+            T_DNUMBER,
+            T_ENCAPSED_AND_WHITESPACE,
+            T_LNUMBER,
+            T_NUM_STRING,
+            T_STRING,
+            T_VARIABLE,
+        ];
+
+        if (in_array($tokens[$previousEffective]['code'], $possibleOperandTypes, true)) {
+            return;
+        }
+
+        $whitespacePointer = $pointer + 1;
+        if (! isset($tokens[$whitespacePointer])) {
+            return;
+        }
+
+        $numberOfSpaces = $this->numberOfSpaces($tokens[$whitespacePointer]);
+        $expectedSpaces = $this->requireSpace ? 1 : 0;
+
+        if ($numberOfSpaces === $expectedSpaces
+            || ! $this->recordError($file, $pointer, $tokens[$pointer], $expectedSpaces, $numberOfSpaces)) {
+            return;
+        }
+
+        if ($expectedSpaces > $numberOfSpaces) {
+            $file->fixer->addContent($pointer, ' ');
+
+            return;
+        }
+
+        $file->fixer->replaceToken($whitespacePointer, '');
+    }
+
+    /**
+     * @param mixed[] $token
+     */
+    private function numberOfSpaces(array $token) : int
+    {
+        if ($token['code'] !== T_WHITESPACE) {
+            return 0;
+        }
+
+        return strlen($token['content']);
+    }
+
+    /**
+     * @param mixed[] $token
+     */
+    private function recordError(File $file, int $pointer, array $token, int $expected, int $found) : bool
+    {
+        return $file->addFixableError(
+            'Expected exactly %d space after "%s"; %d found',
+            $pointer,
+            self::CODE_INVALID_SPACE_AFTER_MINUS,
+            [$expected, $token['content'], $found]
+        );
+    }
+}

--- a/lib/Doctrine/Sniffs/Operators/OperatorSpacingSniff.php
+++ b/lib/Doctrine/Sniffs/Operators/OperatorSpacingSniff.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Sniffs\Operators;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\OperatorSpacingSniff as SquizOperatorSpacingSniff;
+use PHP_CodeSniffer\Util\Tokens;
+use function in_array;
+use const T_ARRAY_CAST;
+use const T_BOOL_CAST;
+use const T_DOUBLE_CAST;
+use const T_ECHO;
+use const T_INT_CAST;
+use const T_MINUS;
+use const T_OBJECT_CAST;
+use const T_PLUS;
+use const T_PRINT;
+use const T_STRING_CAST;
+use const T_UNSET_CAST;
+use const T_YIELD;
+
+/**
+ * We need this sniff until Squiz accepts fix for unary operands detection
+ * https://github.com/squizlabs/PHP_CodeSniffer/pull/2640
+ */
+final class OperatorSpacingSniff extends SquizOperatorSpacingSniff
+{
+    private const NON_OPERAND_TOKENS = [
+        T_ARRAY_CAST,
+        T_BOOL_CAST,
+        T_DOUBLE_CAST,
+        T_ECHO,
+        T_INT_CAST,
+        T_OBJECT_CAST,
+        T_PRINT,
+        T_STRING_CAST,
+        T_UNSET_CAST,
+        T_YIELD,
+    ];
+
+    /**
+     * @param int $pointer
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+     */
+    public function process(File $file, $pointer) : void
+    {
+        if (! $this->isOperator($file, $pointer)) {
+            return;
+        }
+
+        parent::process($file, $pointer);
+    }
+
+    /**
+     * @param int $pointer
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+     */
+    protected function isOperator(File $file, $pointer) : bool
+    {
+        if (! parent::isOperator($file, $pointer)) {
+            return false;
+        }
+
+        $tokens = $file->getTokens();
+        if ($tokens[$pointer]['code'] === T_MINUS || $tokens[$pointer]['code'] === T_PLUS) {
+            $prev = $file->findPrevious(Tokens::$emptyTokens, $pointer - 1, null, true);
+            if (in_array($tokens[$prev]['code'], self::NON_OPERAND_TOKENS, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -16,6 +16,12 @@
         <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterVariadic"/>
     </rule>
 
+    <!-- Require spaces around math, comparison, assignment, ... operators -->
+    <rule ref="Doctrine.Operators.OperatorSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
     <!-- Force array element indentation with 4 spaces -->
     <rule ref="Generic.Arrays.ArrayIndent"/>
     <!-- Forbid `array(...)` -->

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    colors="true"
+    bootstrap="tests/bootstrap.php"
+    executionOrder="random"
+>
+    <testsuite name="Doctrine Coding Standard">
+        <directory>tests</directory>
+    </testsuite>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Sniffs/Operators/NegationOperatorSpacingSniffTest.php
+++ b/tests/Sniffs/Operators/NegationOperatorSpacingSniffTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Sniffs\Operators;
+
+use Doctrine\Tests\TestCase;
+
+class NegationOperatorSpacingSniffTest extends TestCase
+{
+    public function testNoErrors() : void
+    {
+        self::assertNoSniffErrorInFile(self::checkFile(__DIR__ . '/data/NegationOperatorSpacingSniffNoErrors.php'));
+    }
+
+    public function testErrors() : void
+    {
+        $file = self::checkFile(
+            __DIR__ . '/data/NegationOperatorSpacingSniffRequireSpaceErrors.php',
+            ['requireSpace' => true]
+        );
+
+        self::assertSame(97, $file->getErrorCount());
+
+        self::assertAllFixedInFile($file);
+    }
+}

--- a/tests/Sniffs/Operators/OperatorSpacingSniffTest.php
+++ b/tests/Sniffs/Operators/OperatorSpacingSniffTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Sniffs\Operators;
+
+use Doctrine\Tests\TestCase;
+
+class OperatorSpacingSniffTest extends TestCase
+{
+    public function testNoErrors() : void
+    {
+        self::assertNoSniffErrorInFile(
+            self::checkFile(
+                __DIR__ . '/data/OperatorSpacingSniffNoErrors.php',
+                ['ignoreSpacingBeforeAssignments' => false]
+            )
+        );
+    }
+
+    public function testErrors() : void
+    {
+        $file = self::checkFile(
+            __DIR__ . '/data/OperatorSpacingSniffErrors.php',
+            ['ignoreSpacingBeforeAssignments' => false]
+        );
+
+        self::assertSame(67, $file->getErrorCount());
+
+        self::assertAllFixedInFile($file);
+    }
+}

--- a/tests/Sniffs/Operators/data/NegationOperatorSpacingSniffNoErrors.php
+++ b/tests/Sniffs/Operators/data/NegationOperatorSpacingSniffNoErrors.php
@@ -1,0 +1,108 @@
+<?php
+
+$a = $a-$b;
+$a = $a  -  $b;
+$a =  -$a;
+$a =  self::CONST-  $a;
+$a = -(15 + 3);
+if ($a > -16 || $a > -$b || $a > -self::CONSTANT) {
+
+}
+
+
+yield -1;
+echo -1;
+$a = -1;
+func(-1);
+$a = [-1];
+return -1;
+print -1;
+$a &= -1;
+switch ($a) {
+    case -1:
+}
+$a = $a ?? -1;
+$a .= -1;
+$a /= -1;
+$a = [1 => -1];
+$a = $a == -1;
+$a = $a >= -1;
+$a = $a === -1;
+$a = $a != -1;
+$a = $a !== -1;
+$a = $a <= -1;
+$a = $a <=> -1;
+$a = $a and -1;
+$a = $a or -1;
+$a = $a xor -1;
+$a -= -1;
+$a %= -1;
+$a *= -1;
+$a |= -1;
+$a += -1;
+$a = $a ** -1;
+$a **= -1;
+$a = $a << -1;
+$a <<= -1;
+$a = $a >> -1;
+$a >>= -1;
+$a = (string) -1;
+$a = (array) -1;
+$a = (bool) -1;
+$a = (object) -1;
+$a = (unset) -1;
+$a = (float) -1;
+$a = (int) -1;
+$a ^= -1;
+$a = [$a, -1];
+$a = $a[-1];
+$a = $a ? -1 : -1;
+
+
+yield -$b;
+echo -$b;
+$a = -$b;
+func(-$b);
+$a = [-$b];
+return -$b;
+print -$b;
+$a &= -$b;
+switch ($a) {
+    case -$b:
+}
+$a = $a ?? -$b;
+$a .= -$b;
+$a /= -$b;
+$a = [1 => -$b];
+$a = $a == -$b;
+$a = $a >= -$b;
+$a = $a === -$b;
+$a = $a != -$b;
+$a = $a !== -$b;
+$a = $a <= -$b;
+$a = $a <=> -$b;
+$a = $a and -$b;
+$a = $a or -$b;
+$a = $a xor -$b;
+$a -= -$b;
+$a %= -$b;
+$a *= -$b;
+$a |= -$b;
+$a += -$b;
+$a = $a ** -$b;
+$a **= -$b;
+$a = $a << -$b;
+$a <<= -$b;
+$a = $a >> -$b;
+$a >>= -$b;
+$a = (string) -$b;
+$a = (array) -$b;
+$a = (bool) -$b;
+$a = (object) -$b;
+$a = (unset) -$b;
+$a = (float) -$b;
+$a = (int) -$b;
+$a ^= -$b;
+$a = [$a, -$b];
+$a = $a[-$b];
+$a = $a ? -$b : -$b;

--- a/tests/Sniffs/Operators/data/NegationOperatorSpacingSniffRequireSpaceErrors.fixed.php
+++ b/tests/Sniffs/Operators/data/NegationOperatorSpacingSniffRequireSpaceErrors.fixed.php
@@ -1,0 +1,108 @@
+<?php
+
+$a = $a-$b;
+$a = $a  -  $b;
+$a =  - $a;
+$a =  self::CONST-  $a;
+$a = - (15 + 3);
+if ($a > - 16 || $a > - $b || $a > - self::CONSTANT) {
+
+}
+
+
+yield - 1;
+echo - 1;
+$a = - 1;
+func(- 1);
+$a = [- 1];
+return - 1;
+print - 1;
+$a &= - 1;
+switch ($a) {
+    case - 1:
+}
+$a = $a ?? - 1;
+$a .= - 1;
+$a /= - 1;
+$a = [1 => - 1];
+$a = $a == - 1;
+$a = $a >= - 1;
+$a = $a === - 1;
+$a = $a != - 1;
+$a = $a !== - 1;
+$a = $a <= - 1;
+$a = $a <=> - 1;
+$a = $a and - 1;
+$a = $a or - 1;
+$a = $a xor - 1;
+$a -= - 1;
+$a %= - 1;
+$a *= - 1;
+$a |= - 1;
+$a += - 1;
+$a = $a ** - 1;
+$a **= - 1;
+$a = $a << - 1;
+$a <<= - 1;
+$a = $a >> - 1;
+$a >>= - 1;
+$a = (string) - 1;
+$a = (array) - 1;
+$a = (bool) - 1;
+$a = (object) - 1;
+$a = (unset) - 1;
+$a = (float) - 1;
+$a = (int) - 1;
+$a ^= - 1;
+$a = [$a, - 1];
+$a = $a[- 1];
+$a = $a ? - 1 : - 1;
+
+
+yield - $b;
+echo - $b;
+$a = - $b;
+func(- $b);
+$a = [- $b];
+return - $b;
+print - $b;
+$a &= - $b;
+switch ($a) {
+    case - $b:
+}
+$a = $a ?? - $b;
+$a .= - $b;
+$a /= - $b;
+$a = [1 => - $b];
+$a = $a == - $b;
+$a = $a >= - $b;
+$a = $a === - $b;
+$a = $a != - $b;
+$a = $a !== - $b;
+$a = $a <= - $b;
+$a = $a <=> - $b;
+$a = $a and - $b;
+$a = $a or - $b;
+$a = $a xor - $b;
+$a -= - $b;
+$a %= - $b;
+$a *= - $b;
+$a |= - $b;
+$a += - $b;
+$a = $a ** - $b;
+$a **= - $b;
+$a = $a << - $b;
+$a <<= - $b;
+$a = $a >> - $b;
+$a >>= - $b;
+$a = (string) - $b;
+$a = (array) - $b;
+$a = (bool) - $b;
+$a = (object) - $b;
+$a = (unset) - $b;
+$a = (float) - $b;
+$a = (int) - $b;
+$a ^= - $b;
+$a = [$a, - $b];
+$a = $a[- $b];
+$a = $a ? - $b : - $b;

--- a/tests/Sniffs/Operators/data/NegationOperatorSpacingSniffRequireSpaceErrors.php
+++ b/tests/Sniffs/Operators/data/NegationOperatorSpacingSniffRequireSpaceErrors.php
@@ -1,0 +1,108 @@
+<?php
+
+$a = $a-$b;
+$a = $a  -  $b;
+$a =  -$a;
+$a =  self::CONST-  $a;
+$a = -(15 + 3);
+if ($a > -16 || $a > -$b || $a > -self::CONSTANT) {
+
+}
+
+
+yield -1;
+echo -1;
+$a = -1;
+func(-1);
+$a = [-1];
+return -1;
+print -1;
+$a &= -1;
+switch ($a) {
+    case -1:
+}
+$a = $a ?? -1;
+$a .= -1;
+$a /= -1;
+$a = [1 => -1];
+$a = $a == -1;
+$a = $a >= -1;
+$a = $a === -1;
+$a = $a != -1;
+$a = $a !== -1;
+$a = $a <= -1;
+$a = $a <=> -1;
+$a = $a and -1;
+$a = $a or -1;
+$a = $a xor -1;
+$a -= -1;
+$a %= -1;
+$a *= -1;
+$a |= -1;
+$a += -1;
+$a = $a ** -1;
+$a **= -1;
+$a = $a << -1;
+$a <<= -1;
+$a = $a >> -1;
+$a >>= -1;
+$a = (string) -1;
+$a = (array) -1;
+$a = (bool) -1;
+$a = (object) -1;
+$a = (unset) -1;
+$a = (float) -1;
+$a = (int) -1;
+$a ^= -1;
+$a = [$a, -1];
+$a = $a[-1];
+$a = $a ? -1 : -1;
+
+
+yield -$b;
+echo -$b;
+$a = -$b;
+func(-$b);
+$a = [-$b];
+return -$b;
+print -$b;
+$a &= -$b;
+switch ($a) {
+    case -$b:
+}
+$a = $a ?? -$b;
+$a .= -$b;
+$a /= -$b;
+$a = [1 => -$b];
+$a = $a == -$b;
+$a = $a >= -$b;
+$a = $a === -$b;
+$a = $a != -$b;
+$a = $a !== -$b;
+$a = $a <= -$b;
+$a = $a <=> -$b;
+$a = $a and -$b;
+$a = $a or -$b;
+$a = $a xor -$b;
+$a -= -$b;
+$a %= -$b;
+$a *= -$b;
+$a |= -$b;
+$a += -$b;
+$a = $a ** -$b;
+$a **= -$b;
+$a = $a << -$b;
+$a <<= -$b;
+$a = $a >> -$b;
+$a >>= -$b;
+$a = (string) -$b;
+$a = (array) -$b;
+$a = (bool) -$b;
+$a = (object) -$b;
+$a = (unset) -$b;
+$a = (float) -$b;
+$a = (int) -$b;
+$a ^= -$b;
+$a = [$a, -$b];
+$a = $a[-$b];
+$a = $a ? -$b : -$b;

--- a/tests/Sniffs/Operators/data/OperatorSpacingSniffErrors.fixed.php
+++ b/tests/Sniffs/Operators/data/OperatorSpacingSniffErrors.fixed.php
@@ -1,0 +1,42 @@
+<?php
+
+$a = $b;
+$a === $b;
+$a > $b;
+$a >= $b;
+$a < $b;
+$a <= $b;
+$a != $b;
+
+$a = $b;
+$a === $b;
+$a > $b;
+$a >= $b;
+$a < $b;
+$a <= $b;
+$a != $b;
+
+$a = $a + $b;
+$a = $a - $b;
+$a = $a / $b;
+$a = $a * $b;
+$a = $a + $b;
+$a = $a ^ $b;
+
+$a = $a + $b;
+$a = $a - $b;
+$a = $a / $b;
+$a = $a * $b;
+$a = $a + $b;
+$a = $a ^ $b;
+
+$a = self::CONST - $a;
+
+$a += $b;
+$a -= $b;
+
+$a += $b;
+$a -= $b;
+
+$a = ($a) instanceof $b;
+$a = $a instanceof $b;

--- a/tests/Sniffs/Operators/data/OperatorSpacingSniffErrors.php
+++ b/tests/Sniffs/Operators/data/OperatorSpacingSniffErrors.php
@@ -1,0 +1,42 @@
+<?php
+
+$a=$b;
+$a===$b;
+$a>$b;
+$a>=$b;
+$a<$b;
+$a<=$b;
+$a!=$b;
+
+$a  =  $b;
+$a  ===  $b;
+$a  >  $b;
+$a  >=  $b;
+$a  <  $b;
+$a  <=  $b;
+$a  !=  $b;
+
+$a = $a+$b;
+$a = $a-$b;
+$a = $a/$b;
+$a = $a*$b;
+$a = $a+$b;
+$a = $a^$b;
+
+$a = $a  +  $b;
+$a = $a  -  $b;
+$a = $a  /  $b;
+$a = $a  *  $b;
+$a = $a  +  $b;
+$a = $a  ^  $b;
+
+$a =  self::CONST-  $a;
+
+$a+=$b;
+$a-=$b;
+
+$a  +=  $b;
+$a  -=  $b;
+
+$a = ($a)instanceof$b;
+$a = $a  instanceof  $b;

--- a/tests/Sniffs/Operators/data/OperatorSpacingSniffNoErrors.php
+++ b/tests/Sniffs/Operators/data/OperatorSpacingSniffNoErrors.php
@@ -1,0 +1,194 @@
+<?php
+
+yield -1;
+echo -1;
+$a = -1;
+func(-1);
+$a = [-1];
+return -1;
+print -1;
+$a &= -1;
+switch ($a) {
+    case -1:
+}
+$a = $a ?? -1;
+$a .= -1;
+$a /= -1;
+$a = [1 => -1];
+$a = $a == -1;
+$a = $a >= -1;
+$a = $a === -1;
+$a = $a != -1;
+$a = $a !== -1;
+$a = $a <= -1;
+$a = $a <=> -1;
+$a = $a and -1;
+$a = $a or -1;
+$a = $a xor -1;
+$a -= -1;
+$a %= -1;
+$a *= -1;
+$a |= -1;
+$a += -1;
+$a = $a ** -1;
+$a **= -1;
+$a = $a << -1;
+$a <<= -1;
+$a = $a >> -1;
+$a >>= -1;
+$a = (string) -1;
+$a = (array) -1;
+$a = (bool) -1;
+$a = (object) -1;
+$a = (unset) -1;
+$a = (float) -1;
+$a = (int) -1;
+$a ^= -1;
+$a = [$a, -1];
+$a = $a[-1];
+$a = $a ? -1 : -1;
+
+yield - 1;
+echo - 1;
+$a = - 1;
+func(- 1);
+$a = [- 1];
+return - 1;
+print - 1;
+$a &= - 1;
+switch ($a) {
+    case - 1:
+}
+$a = $a ?? - 1;
+$a .= - 1;
+$a /= - 1;
+$a = [1 => - 1];
+$a = $a == - 1;
+$a = $a >= - 1;
+$a = $a === - 1;
+$a = $a != - 1;
+$a = $a !== - 1;
+$a = $a <= - 1;
+$a = $a <=> - 1;
+$a = $a and - 1;
+$a = $a or - 1;
+$a = $a xor - 1;
+$a -= - 1;
+$a %= - 1;
+$a *= - 1;
+$a |= - 1;
+$a += - 1;
+$a = $a ** - 1;
+$a **= - 1;
+$a = $a << - 1;
+$a <<= - 1;
+$a = $a >> - 1;
+$a >>= - 1;
+$a = (string) - 1;
+$a = (array) - 1;
+$a = (bool) - 1;
+$a = (object) - 1;
+$a = (unset) - 1;
+$a = (float) - 1;
+$a = (int) - 1;
+$a ^= - 1;
+$a = [$a, - 1];
+$a = $a[- 1];
+$a = $a ? - 1 : - 1;
+
+
+yield -$b;
+echo -$b;
+$a = -$b;
+func(-$b);
+$a = [-$b];
+return -$b;
+print -$b;
+$a &= -$b;
+switch ($a) {
+    case -$b:
+}
+$a = $a ?? -$b;
+$a .= -$b;
+$a /= -$b;
+$a = [1 => -$b];
+$a = $a == -$b;
+$a = $a >= -$b;
+$a = $a === -$b;
+$a = $a != -$b;
+$a = $a !== -$b;
+$a = $a <= -$b;
+$a = $a <=> -$b;
+$a = $a and -$b;
+$a = $a or -$b;
+$a = $a xor -$b;
+$a -= -$b;
+$a %= -$b;
+$a *= -$b;
+$a |= -$b;
+$a += -$b;
+$a = $a ** -$b;
+$a **= -$b;
+$a = $a << -$b;
+$a <<= -$b;
+$a = $a >> -$b;
+$a >>= -$b;
+$a = (string) -$b;
+$a = (array) -$b;
+$a = (bool) -$b;
+$a = (object) -$b;
+$a = (unset) -$b;
+$a = (float) -$b;
+$a = (int) -$b;
+$a ^= -$b;
+$a = [$a, -$b];
+$a = $a[-$b];
+$a = $a ? -$b : -$b;
+
+yield - $b;
+echo - $b;
+$a = - $b;
+func(- $b);
+$a = [- $b];
+return - $b;
+print - $b;
+$a &= - $b;
+switch ($a) {
+    case - $b:
+}
+$a = $a ?? - $b;
+$a .= - $b;
+$a /= - $b;
+$a = [1 => - $b];
+$a = $a == - $b;
+$a = $a >= - $b;
+$a = $a === - $b;
+$a = $a != - $b;
+$a = $a !== - $b;
+$a = $a <= - $b;
+$a = $a <=> - $b;
+$a = $a and - $b;
+$a = $a or - $b;
+$a = $a xor - $b;
+$a -= - $b;
+$a %= - $b;
+$a *= - $b;
+$a |= - $b;
+$a += - $b;
+$a = $a ** - $b;
+$a **= - $b;
+$a = $a << - $b;
+$a <<= - $b;
+$a = $a >> - $b;
+$a >>= - $b;
+$a = (string) - $b;
+$a = (array) - $b;
+$a = (bool) - $b;
+$a = (object) - $b;
+$a = (unset) - $b;
+$a = (float) - $b;
+$a = (int) - $b;
+$a ^= - $b;
+$a = [$a, - $b];
+$a = $a[- $b];
+$a = $a ? - $b : - $b;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests;
+
+use SlevomatCodingStandard\Sniffs\TestCase as SlevomatTestCase;
+use function str_replace;
+use function strlen;
+use function substr;
+
+abstract class TestCase extends SlevomatTestCase
+{
+    protected static function getSniffClassName() : string
+    {
+        return str_replace('\\Tests\\', '\\', substr(static::class, 0, -strlen('Test')));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../vendor/squizlabs/php_codesniffer/autoload.php';
+require __DIR__ . '/../vendor/squizlabs/php_codesniffer/src/Util/Tokens.php';

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -6,7 +6,7 @@ FILE                                                  ERRORS  WARNINGS
 tests/input/array_indentation.php                     10      0
 tests/input/assignment-operators.php                  4       0
 tests/input/class-references.php                      10      0
-tests/input/concatenation_spacing.php                 24      0
+tests/input/concatenation_spacing.php                 27      0
 tests/input/constants-no-lsb.php                      2       0
 tests/input/constants-var.php                         3       0
 tests/input/doc-comment-spacing.php                   10      0
@@ -37,9 +37,9 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 272 ERRORS AND 0 WARNINGS WERE FOUND IN 33 FILES
+A TOTAL OF 275 ERRORS AND 0 WARNINGS WERE FOUND IN 33 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 217 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 220 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/concatenation_spacing.php
+++ b/tests/fixed/concatenation_spacing.php
@@ -27,9 +27,9 @@ $string = $doctrine . 'rulez';
 
 $string = $doctrine . $rulez . 'even' . 'more' . $string;
 
-$string .=$doctrine;
 $string .= $doctrine;
-$string .=$doctrine;
+$string .= $doctrine;
+$string .= $doctrine;
 
 $string = $doctrine .
     $rulez .

--- a/tests/fixed/trailing_comma_on_array.php
+++ b/tests/fixed/trailing_comma_on_array.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-$array =  [
+$array = [
     'key1' => 'value',
     'key2' => 'value',
 ];

--- a/tests/input/trailing_comma_on_array.php
+++ b/tests/input/trailing_comma_on_array.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-$array =  [
+$array = [
     'key1' => 'value',
     'key2' => 'value'
 ];


### PR DESCRIPTION
PR created in response to discussion at https://github.com/doctrine/coding-standard/pull/123 (requested here https://github.com/doctrine/coding-standard/pull/123#issuecomment-538651747 )

PHPCS v3.5 with custom properties replaces our current solution mentioned by @simPod, but it still has some issues, so this is the current state: https://github.com/cdn77/coding-standard/commit/e67d29456c978784b44e30aaff768c7e257e3166

The other thing that solves operator spacing is our NegationOperatorSpacingSniff which focuses only on the T_MINUS used as a unary operator. This will also be probably dropped when the https://github.com/squizlabs/PHP_CodeSniffer/pull/2456 merges, https://github.com/squizlabs/PHP_CodeSniffer/pull/2456/commits/82366dbf0b3c7d577078bcf98f711c0308bb35a6 to be more precise.

I took the liberty of adjusting the composer.json and providing simple bootstrap/base test case to test the NegationOperatorSpacingSniff (the code is exactly same as the source on https://github.com/cdn77/coding-standard ) - please feel free to adjust it to your liking ;-)