### PR TITLE
Bump slevomat cs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^7.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-        "slevomat/coding-standard": "dev-master#63a8186b129ee96d1277e68c80cf87c8cdb356d1",
+        "slevomat/coding-standard": "dev-master#9401aac3b076250dfcbfe391a53f9fea4b2c5201",
         "squizlabs/php_codesniffer": "^3.5.0"
     },
     "config": {

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -205,18 +205,18 @@
     <rule ref="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment"/>
     <!-- Forbid assignments in conditions -->
     <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
-    <!-- Require consistent spacing for control structures -->
-    <rule ref="SlevomatCodingStandard.ControlStructures.ControlStructureSpacing">
+    <!-- Forbid fancy yoda conditions -->
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
+    <!-- Require usage of early exit -->
+    <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
+    <!-- Require consistent spacing for jump statements -->
+    <rule ref="SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing">
         <properties>
             <property name="tokensToCheck" type="array">
                 <element value="T_RETURN" />
             </property>
         </properties>
     </rule>
-    <!-- Forbid fancy yoda conditions -->
-    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
-    <!-- Require usage of early exit -->
-    <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
     <!-- Require language constructs without parentheses -->
     <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses"/>
     <!-- Require new instances with parentheses -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -8,14 +8,14 @@ tests/input/assignment-operators.php                  4       0
 tests/input/class-references.php                      10      0
 tests/input/concatenation_spacing.php                 24      0
 tests/input/constants-no-lsb.php                      2       0
-tests/input/constants-var.php                         3       0
+tests/input/constants-var.php                         4       0
 tests/input/doc-comment-spacing.php                   10      0
 tests/input/duplicate-assignment-variable.php         1       0
 tests/input/EarlyReturn.php                           6       0
 tests/input/example-class.php                         33      0
 tests/input/forbidden-comments.php                    8       0
 tests/input/forbidden-functions.php                   6       0
-tests/input/inline_type_hint_assertions.php           6       0
+tests/input/inline_type_hint_assertions.php           7       0
 tests/input/LowCaseTypes.php                          2       0
 tests/input/namespaces-spacing.php                    7       0
 tests/input/NamingCamelCase.php                       7       0
@@ -37,7 +37,7 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 272 ERRORS AND 0 WARNINGS WERE FOUND IN 33 FILES
+A TOTAL OF 274 ERRORS AND 0 WARNINGS WERE FOUND IN 33 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 217 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------


### PR DESCRIPTION
The workshop in slevomat/coding-standard ignited its furnaces after a while so I though it's time to bump its version a bit forward.

Notable BC break to mind there is https://github.com/slevomat/coding-standard/commit/ea725d3036a203a0939a38cfc7a1826c88c8eabb