### PR TITLE
Do or do not require spaces before control structures?

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -206,7 +206,10 @@
     <!-- Forbid assignments in conditions -->
     <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
     <!-- Require consistent spacing for block structures -->
-    <rule ref="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing">
+        <exclude name="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing.IncorrectLinesCountBeforeControlStructure" />
+        <exclude name="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing.IncorrectLinesCountBeforeFirstControlStructure" />
+    </rule>
     <!-- Forbid fancy yoda conditions -->
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
     <!-- Require usage of early exit -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -12,7 +12,7 @@ tests/input/constants-var.php                         4       0
 tests/input/doc-comment-spacing.php                   10      0
 tests/input/duplicate-assignment-variable.php         1       0
 tests/input/EarlyReturn.php                           6       0
-tests/input/example-class.php                         48      0
+tests/input/example-class.php                         45      0
 tests/input/forbidden-comments.php                    8       0
 tests/input/forbidden-functions.php                   6       0
 tests/input/inline_type_hint_assertions.php           7       0
@@ -37,9 +37,9 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 289 ERRORS AND 0 WARNINGS WERE FOUND IN 33 FILES
+A TOTAL OF 286 ERRORS AND 0 WARNINGS WERE FOUND IN 33 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 232 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 229 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/example-class.php
+++ b/tests/fixed/example-class.php
@@ -127,6 +127,7 @@ class Example implements IteratorAggregate
     public function trySwitchSpace() : void
     {
         try {
+            $var = 1;
             switch (self::VERSION) {
                 default:
             }

--- a/tests/input/example-class.php
+++ b/tests/input/example-class.php
@@ -122,6 +122,7 @@ class Example implements \IteratorAggregate
     public function trySwitchSpace() : void
     {
         try {
+            $var = 1;
             switch (self::VERSION) {
                 default:
             }


### PR DESCRIPTION
I guess this PR is last in my series. This disables new and probably not desired behaviour introduced in https://github.com/doctrine/coding-standard/pull/137 (mentioned https://github.com/doctrine/coding-standard/pull/137#issuecomment-558961400).

We want to require spaces after control structures but not before (at least this is original behaviour).