### PR TITLE
Crumble removed TypeHintDeclaration sniff

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
     "require": {
         "php": "^7.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-        "slevomat/coding-standard": "dev-master#469368cc6d8fe83aceba259ef65f1c0a2f63055b",
-        "squizlabs/php_codesniffer": "^3.5.0"
+        "slevomat/coding-standard": "^6.0",
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "config": {
         "sort-packages": true

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -338,6 +338,9 @@
         <properties>
             <property name="traversableTypeHints" type="array">
                 <element value="Traversable"/>
+                <element value="Iterator"/>
+                <element value="IteratorAggregate"/>
+                <element value="Doctrine\Common\Collections\Collection"/>
             </property>
         </properties>
     </rule>
@@ -346,6 +349,9 @@
             <property name="enableNativeTypeHint" value="false"/>
             <property name="traversableTypeHints" type="array">
                 <element value="Traversable"/>
+                <element value="Iterator"/>
+                <element value="IteratorAggregate"/>
+                <element value="Doctrine\Common\Collections\Collection"/>
             </property>
         </properties>
     </rule>
@@ -353,6 +359,9 @@
         <properties>
             <property name="traversableTypeHints" type="array">
                 <element value="Traversable"/>
+                <element value="Iterator"/>
+                <element value="IteratorAggregate"/>
+                <element value="Doctrine\Common\Collections\Collection"/>
             </property>
         </properties>
     </rule>
@@ -363,6 +372,9 @@
         <properties>
             <property name="traversableTypeHints" type="array">
                 <element value="Traversable"/>
+                <element value="Iterator"/>
+                <element value="IteratorAggregate"/>
+                <element value="Doctrine\Common\Collections\Collection"/>
             </property>
         </properties>
     </rule>

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -334,10 +334,23 @@
     <!-- Require types to be written as natively if possible;
          require iterable types to specify phpDoc with their content;
          forbid useless/duplicated information in phpDoc -->
-    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
         <properties>
-            <property name="allAnnotationsAreUseful" value="true"/>
-            <property name="enableEachParameterAndReturnInspection" value="true"/>
+            <property name="traversableTypeHints" type="array">
+                <element value="Doctrine\Common\Collections\Collection"/>
+            </property>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
+        <properties>
+            <property name="enableNativeTypeHint" value="false"/>
+            <property name="traversableTypeHints" type="array">
+                <element value="Doctrine\Common\Collections\Collection"/>
+            </property>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
+        <properties>
             <property name="traversableTypeHints" type="array">
                 <element value="Doctrine\Common\Collections\Collection"/>
             </property>
@@ -345,6 +358,16 @@
     </rule>
     <!-- Forbid useless @var for constants -->
     <rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"/>
+    <!-- Forbid useless phpDocs for functions -->
+    <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment">
+        <properties>
+            <property name="traversableTypeHints" type="array">
+                <element value="Doctrine\Common\Collections\Collection"/>
+            </property>
+        </properties>
+    </rule>
+    <!-- Forbid useless inherit doc comment -->
+    <rule ref="SlevomatCodingStandard.Commenting.UselessInheritDocComment"/>
     <!-- Forbid duplicated variables assignments -->
     <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable"/>
     <!-- Forbid useless variables -->

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -337,7 +337,7 @@
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
         <properties>
             <property name="traversableTypeHints" type="array">
-                <element value="Doctrine\Common\Collections\Collection"/>
+                <element value="Traversable"/>
             </property>
         </properties>
     </rule>
@@ -345,14 +345,14 @@
         <properties>
             <property name="enableNativeTypeHint" value="false"/>
             <property name="traversableTypeHints" type="array">
-                <element value="Doctrine\Common\Collections\Collection"/>
+                <element value="Traversable"/>
             </property>
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
         <properties>
             <property name="traversableTypeHints" type="array">
-                <element value="Doctrine\Common\Collections\Collection"/>
+                <element value="Traversable"/>
             </property>
         </properties>
     </rule>
@@ -362,7 +362,7 @@
     <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment">
         <properties>
             <property name="traversableTypeHints" type="array">
-                <element value="Doctrine\Common\Collections\Collection"/>
+                <element value="Traversable"/>
             </property>
         </properties>
     </rule>

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -38,7 +38,7 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 289 ERRORS AND 0 WARNINGS WERE FOUND IN 33 FILES
+A TOTAL OF 293 ERRORS AND 0 WARNINGS WERE FOUND IN 34 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 232 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -32,6 +32,7 @@ tests/input/superfluous-naming.php                    11      0
 tests/input/test-case.php                             8       0
 tests/input/trailing_comma_on_array.php               1       0
 tests/input/traits-uses.php                           11      0
+tests/input/type-hints.php                            4       0
 tests/input/UnusedVariables.php                       1       0
 tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0

--- a/tests/fixed/type-hints.php
+++ b/tests/fixed/type-hints.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypeHints;
+
+use Iterator;
+use Traversable;
+
+class TraversableTypeHints
+{
+    /** @var Traversable */
+    private $parameter;
+
+    /**
+     * @param Iterator $iterator
+     *
+     * @return Traversable
+     */
+    public function get(Iterator $iterator) : Traversable
+    {
+        return $this->parameter;
+    }
+}

--- a/tests/fixed/type-hints.php
+++ b/tests/fixed/type-hints.php
@@ -9,13 +9,13 @@ use Traversable;
 
 class TraversableTypeHints
 {
-    /** @var Traversable */
+    /** @var Traversable|string[] */
     private $parameter;
 
     /**
-     * @param Iterator $iterator
+     * @param Iterator|string[] $iterator
      *
-     * @return Traversable
+     * @return Traversable|string[]
      */
     public function get(Iterator $iterator) : Traversable
     {

--- a/tests/fixed/type-hints.php
+++ b/tests/fixed/type-hints.php
@@ -9,13 +9,13 @@ use Traversable;
 
 class TraversableTypeHints
 {
-    /** @var Traversable|string[] */
+    /** @var Traversable */
     private $parameter;
 
     /**
-     * @param Iterator|string[] $iterator
+     * @param Iterator $iterator
      *
-     * @return Traversable|string[]
+     * @return Traversable
      */
     public function get(Iterator $iterator) : Traversable
     {

--- a/tests/input/type-hints.php
+++ b/tests/input/type-hints.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypeHints;
+
+use Iterator;
+use Traversable;
+
+class TraversableTypeHints
+{
+    /** @var Traversable */
+    private $parameter;
+
+    /**
+     * @param Iterator $iterator
+     *
+     * @return Traversable
+     */
+    public function get(Iterator $iterator) : Traversable
+    {
+        return $this->parameter;
+    }
+}


### PR DESCRIPTION
Introduced in https://github.com/slevomat/coding-standard/commit/7db89bee53a4f841cbd5d88efa473af6148cc027

Disable TypeHintDeclaration
Enable
- ParameterTypeHint
- PropertyTypeHint
- ReturnTypeHint
- UselessFunctionDocComment

Build currently fails, there are some features on by default for PHP 7.4. Have to investigate what's the cause and if I can fix it yet.