### PR TITLE
Enable DisallowArrayTypeHintSyntax sniff

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
     "require": {
         "php": "^7.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-        "slevomat/coding-standard": "dev-master#469368cc6d8fe83aceba259ef65f1c0a2f63055b",
-        "squizlabs/php_codesniffer": "^3.5.0"
+        "slevomat/coding-standard": "^6.0",
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "config": {
         "sort-packages": true

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -317,6 +317,8 @@
     <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
     <!-- Require /* @var type $foo */ and similar simple inline annotations to be replaced by assert() -->
     <rule ref="SlevomatCodingStandard.PHP.RequireExplicitAssertion"/>
+    <!-- Disallows usage of array type hint syntax (eg. int[], bool[][]) in phpDocs in favour of generic type hint syntax -->
+    <rule ref="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax"/>
     <!-- Require use of short versions of scalar types (i.e. int instead of integer) -->
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
     <!-- Require the `null` type hint to be in the last position of annotations -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -32,14 +32,15 @@ tests/input/superfluous-naming.php                    11      0
 tests/input/test-case.php                             8       0
 tests/input/trailing_comma_on_array.php               1       0
 tests/input/traits-uses.php                           11      0
+tests/input/type-hints.php                            2       0
 tests/input/UnusedVariables.php                       1       0
 tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 289 ERRORS AND 0 WARNINGS WERE FOUND IN 33 FILES
+A TOTAL OF 231 ERRORS AND 0 WARNINGS WERE FOUND IN 34 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 232 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 233 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/UselessConditions.php
+++ b/tests/fixed/UselessConditions.php
@@ -120,7 +120,7 @@ class UselessConditions
     }
 
     /**
-     * @param string[] $words
+     * @param array<string> $words
      */
     public function uselessTernaryCheck(array $words) : bool
     {

--- a/tests/fixed/doc-comment-spacing.php
+++ b/tests/fixed/doc-comment-spacing.php
@@ -30,7 +30,7 @@ class Test
      *
      * Second Paragraph Description
      *
-     * @param int[] $foo
+     * @param array<int> $foo
      *
      * @throws FooException
      */
@@ -56,10 +56,10 @@ class Test
      * @PHPCR\Uuid
      * @PHPCR\Field
      *
-     * @param int[] $foo
-     * @param int[] $bar
+     * @param array<int> $foo
+     * @param array<int> $bar
      *
-     * @return int[]
+     * @return array<int>
      *
      * @throws FooException
      * @throws BarException

--- a/tests/fixed/example-class.php
+++ b/tests/fixed/example-class.php
@@ -27,7 +27,7 @@ class Example implements IteratorAggregate
     /** @var int|null */
     private $foo;
 
-    /** @var string[] */
+    /** @var array<string> */
     private $bar;
 
     /** @var bool */

--- a/tests/fixed/type-hints.php
+++ b/tests/fixed/type-hints.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypeHints;
+
+class Foo
+{
+    /**
+     * @return iterable<string>
+     */
+    public function names() : iterable
+    {
+        yield 'name1';
+    }
+}

--- a/tests/input/UselessConditions.php
+++ b/tests/input/UselessConditions.php
@@ -152,7 +152,7 @@ class UselessConditions
     }
 
     /**
-     * @param string[] $words
+     * @param array<string> $words
      */
     public function uselessTernaryCheck(array $words) : bool
     {

--- a/tests/input/class-references.php
+++ b/tests/input/class-references.php
@@ -9,7 +9,7 @@ class Foo
 class Bar extends Foo
 {
     /**
-     * @return string[]
+     * @return iterable<string>
      */
     public function names() : iterable
     {

--- a/tests/input/doc-comment-spacing.php
+++ b/tests/input/doc-comment-spacing.php
@@ -32,7 +32,7 @@ class Test
      *
      * Second Paragraph Description
      * @throws FooException
-     * @param int[] $foo
+     * @param array<int> $foo
      */
     public function c(iterable $foo) : void
     {
@@ -43,17 +43,17 @@ class Test
      * Description
      * More Description
      * @throws FooException
-     * @param int[] $foo
+     * @param array<int> $foo
      * @uses other
      * @throws BarException
-     * @return int[]
+     * @return array<int>
      * @ORM\Id
      * @internal
      * @link https://example.com
      * @ODM\Id
      * @deprecated
      * @PHPCR\Uuid
-     * @param int[] $bar
+     * @param array<int> $bar
      * @PHPCR\Field
      * @ODM\Column
      * @ORM\Column

--- a/tests/input/example-class.php
+++ b/tests/input/example-class.php
@@ -22,7 +22,7 @@ class Example implements \IteratorAggregate
     /** @var null|int */
     private $foo;
 
-    /** @var string[] */
+    /** @var array<string> */
     private $bar;
 
     /** @var bool */

--- a/tests/input/type-hints.php
+++ b/tests/input/type-hints.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypeHints;
+
+class Foo
+{
+    /**
+     * @return string[]
+     */
+    public function names() : iterable
+    {
+        yield 'name1';
+    }
+}


### PR DESCRIPTION
> Disallows usage of array type hint syntax (eg. int[], bool[][]) in phpDocs in favour of generic type hint syntax (eg. array<int>, array<array<bool>>).

- added new sniff
- fixed violations in all tests
- added `type-hints` test to cover this (+2 errors, autoloading and `string[]` violation)

_If this passes, I can drop all `traversableTypeHints` settings from https://github.com/doctrine/coding-standard/pull/139#pullrequestreview-326823940_