### PR TITLE
Adopt PSR-12 as base coding standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^7.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-        "slevomat/coding-standard": "^6.0",
+        "slevomat/coding-standard": "^6.0.8",
         "squizlabs/php_codesniffer": "^3.5.3"
     },
     "config": {

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -6,14 +6,23 @@
 >
     <description>The Doctrine coding standard.</description>
 
-    <!-- Import PSR-2 coding standard (base) -->
-    <rule ref="PSR2">
+    <!-- Import PSR-12 coding standard (base) -->
+    <rule ref="PSR12">
         <!-- checked by SlevomatCodingStandard.Namespaces.UseSpacing -->
         <exclude name="PSR2.Namespaces.UseDeclaration.SpaceAfterLastUse"/>
+        <exclude name="PSR12.Files.FileHeader"/>
         <!-- checked by SlevomatCodingStandard.Namespaces.NamespaceSpacing -->
         <exclude name="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter"/>
         <!-- checked by SlevomatCodingStandard.Operators.SpreadOperatorSpacing -->
         <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterVariadic"/>
+        <!-- checked by SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing -->
+        <exclude name="PSR12.Functions.ReturnTypeDeclaration"/>
+        <!-- checked by SlevomatCodingStandard.Classes.TraitUseSpacing -->
+        <exclude name="PSR12.Traits.UseDeclaration"/>
+        <!-- checked by SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing.WhitespaceAfterNullabilitySymbol -->
+        <exclude name="PSR12.Functions.NullableTypeDeclaration.WhitespaceFound"/>
+        <!-- checked by PSR12.ControlStructures.ControlStructureSpacing -->
+        <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace"/>
     </rule>
 
     <!-- Force array element indentation with 4 spaces -->
@@ -239,8 +248,6 @@
     </rule>
     <!-- Require language constructs without parentheses -->
     <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses"/>
-    <!-- Require new instances with parentheses -->
-    <rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
     <!-- Require usage of null coalesce operator when possible -->
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
     <!-- Forbid usage of conditions when a simple return can be used -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -9,7 +9,7 @@ tests/input/class-references.php                      10      0
 tests/input/concatenation_spacing.php                 24      0
 tests/input/constants-no-lsb.php                      2       0
 tests/input/constants-var.php                         4       0
-tests/input/ControlStructures.php                     13      0
+tests/input/ControlStructures.php                     17      0
 tests/input/doc-comment-spacing.php                   10      0
 tests/input/duplicate-assignment-variable.php         1       0
 tests/input/EarlyReturn.php                           6       0
@@ -39,9 +39,9 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 292 ERRORS AND 0 WARNINGS WERE FOUND IN 35 FILES
+A TOTAL OF 296 ERRORS AND 0 WARNINGS WERE FOUND IN 35 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 231 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 235 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/ControlStructures.php
+++ b/tests/fixed/ControlStructures.php
@@ -112,4 +112,19 @@ class ControlStructures
 
         echo 5;
     }
+
+    public function spaceAroundMultilineIfs() : void
+    {
+        if (
+            true
+            && false
+        ) {
+            echo 1;
+        } elseif (
+            false
+            || true
+        ) {
+            echo 2;
+        }
+    }
 }

--- a/tests/fixed/binary_operators.php
+++ b/tests/fixed/binary_operators.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+if ($foo === $bar) {
+    return $bar + $foo;
+}
+
+for ($i = 0; $i < 100; $i++) {
+    echo $i >= 10;
+}

--- a/tests/fixed/concatenation_spacing.php
+++ b/tests/fixed/concatenation_spacing.php
@@ -27,9 +27,9 @@ $string = $doctrine . 'rulez';
 
 $string = $doctrine . $rulez . 'even' . 'more' . $string;
 
-$string .=$doctrine;
 $string .= $doctrine;
-$string .=$doctrine;
+$string .= $doctrine;
+$string .= $doctrine;
 
 $string = $doctrine .
     $rulez .

--- a/tests/fixed/trailing_comma_on_array.php
+++ b/tests/fixed/trailing_comma_on_array.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-$array =  [
+$array = [
     'key1' => 'value',
     'key2' => 'value',
 ];

--- a/tests/input/ControlStructures.php
+++ b/tests/input/ControlStructures.php
@@ -102,4 +102,16 @@ class ControlStructures
         }
         echo 5;
     }
+
+    public function spaceAroundMultilineIfs() : void
+    {
+        if (true
+        && false) {
+            echo 1;
+        } elseif ( false
+            || true
+        ) {
+            echo 2;
+        }
+    }
 }

--- a/tests/input/binary_operators.php
+++ b/tests/input/binary_operators.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+if ($foo===$bar) {
+    return $bar+$foo;
+}
+
+for ($i=0; $i<100; $i++) {
+    echo $i >=10;
+}

--- a/tests/input/trailing_comma_on_array.php
+++ b/tests/input/trailing_comma_on_array.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-$array =  [
+$array = [
     'key1' => 'value',
     'key2' => 'value'
 ];

--- a/tests/php-compatibility.patch
+++ b/tests/php-compatibility.patch
@@ -1,17 +1,27 @@
 diff --git a/tests/expected_report.txt b/tests/expected_report.txt
-index 11b8d1c..5072a64 100644
+index d1fdd9f..a93a3e1 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
-@@ -13,7 +13,7 @@ tests/input/ControlStructures.php                     13      0
+@@ -5,15 +5,16 @@ FILE                                                  ERRORS  WARNINGS
+ ----------------------------------------------------------------------
+ tests/input/array_indentation.php                     10      0
+ tests/input/assignment-operators.php                  4       0
++tests/input/binary_operators.php                      9       0
+ tests/input/class-references.php                      10      0
+-tests/input/concatenation_spacing.php                 24      0
++tests/input/concatenation_spacing.php                 49      0
+ tests/input/constants-no-lsb.php                      2       0
+ tests/input/constants-var.php                         4       0
+ tests/input/ControlStructures.php                     17      0
  tests/input/doc-comment-spacing.php                   10      0
  tests/input/duplicate-assignment-variable.php         1       0
  tests/input/EarlyReturn.php                           6       0
 -tests/input/example-class.php                         34      0
-+tests/input/example-class.php                         37      0
++tests/input/example-class.php                         39      0
  tests/input/forbidden-comments.php                    8       0
  tests/input/forbidden-functions.php                   6       0
  tests/input/inline_type_hint_assertions.php           7       0
-@@ -33,15 +33,15 @@ tests/input/superfluous-naming.php                    11      0
+@@ -33,15 +34,15 @@ tests/input/superfluous-naming.php                    11      0
  tests/input/test-case.php                             8       0
  tests/input/trailing_comma_on_array.php               1       0
  tests/input/traits-uses.php                           11      0
@@ -22,11 +32,11 @@ index 11b8d1c..5072a64 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 292 ERRORS AND 0 WARNINGS WERE FOUND IN 35 FILES
-+A TOTAL OF 296 ERRORS AND 0 WARNINGS WERE FOUND IN 35 FILES
+-A TOTAL OF 296 ERRORS AND 0 WARNINGS WERE FOUND IN 35 FILES
++A TOTAL OF 336 ERRORS AND 0 WARNINGS WERE FOUND IN 36 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 231 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 235 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 235 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 275 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  


### PR DESCRIPTION
This PR proposes that the Doctrine's CS adopts [PSR-12](https://www.php-fig.org/psr/psr-12/) as the base for our standards, with a few changes, [as voted in the past](https://github.com/doctrine/coding-standard/pull/9).

Important changes:
- `SlevomatCodingStandard.ControlStructures.NewWithParentheses` was dropped in favor of `PSR12.Classes.ClassInstantiation`, in specific `PSR12.Classes.ClassInstantiation.MissingParentheses`
- The `tests/fixed/binary_operators.php` was added to ensure the behaviour of a new rule: `PSR12.Operators.OperatorSpacing` (will close #123, #126 as well #134 if approved)