### PR TITLE
Forbid `is_a` function

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -65,6 +65,7 @@
                 <element key="extract" value="null"/>
                 <element key="fputs" value="fwrite"/>
                 <element key="ini_alter" value="ini_set"/>
+                <element key="is_a" value="null"/>
                 <element key="is_double" value="is_float"/>
                 <element key="is_integer" value="is_int"/>
                 <element key="is_long" value="is_int"/>

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -15,7 +15,7 @@ tests/input/duplicate-assignment-variable.php         1       0
 tests/input/EarlyReturn.php                           6       0
 tests/input/example-class.php                         34      0
 tests/input/forbidden-comments.php                    8       0
-tests/input/forbidden-functions.php                   6       0
+tests/input/forbidden-functions.php                   7       0
 tests/input/inline_type_hint_assertions.php           7       0
 tests/input/LowCaseTypes.php                          2       0
 tests/input/namespaces-spacing.php                    7       0
@@ -39,7 +39,7 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 292 ERRORS AND 0 WARNINGS WERE FOUND IN 35 FILES
+A TOTAL OF 293 ERRORS AND 0 WARNINGS WERE FOUND IN 35 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 231 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------

--- a/tests/fixed/forbidden-functions.php
+++ b/tests/fixed/forbidden-functions.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Test;
 
+use stdClass;
 use function chop;
 use function compact;
 use function extract;
+use function is_a;
 use function is_null;
 use function settype;
 use function sizeof;
@@ -28,3 +30,5 @@ $bar = [
 extract($bar);
 
 compact('foo', 'bar');
+
+is_a($bar, stdClass::class);

--- a/tests/input/forbidden-functions.php
+++ b/tests/input/forbidden-functions.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Test;
 
+use stdClass;
 use function chop;
 use function compact;
 use function extract;
+use function is_a;
 use function is_null;
 use function settype;
 use function sizeof;
@@ -28,3 +30,5 @@ $bar = [
 extract($bar);
 
 compact('foo', 'bar');
+
+is_a($bar, stdClass::class);

--- a/tests/php-compatibility.patch
+++ b/tests/php-compatibility.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/expected_report.txt b/tests/expected_report.txt
-index 11b8d1c..5072a64 100644
+index 3bcc0a7..8375ee1 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
 @@ -13,7 +13,7 @@ tests/input/ControlStructures.php                     13      0
@@ -9,7 +9,7 @@ index 11b8d1c..5072a64 100644
 -tests/input/example-class.php                         34      0
 +tests/input/example-class.php                         37      0
  tests/input/forbidden-comments.php                    8       0
- tests/input/forbidden-functions.php                   6       0
+ tests/input/forbidden-functions.php                   7       0
  tests/input/inline_type_hint_assertions.php           7       0
 @@ -33,15 +33,15 @@ tests/input/superfluous-naming.php                    11      0
  tests/input/test-case.php                             8       0
@@ -22,8 +22,8 @@ index 11b8d1c..5072a64 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 292 ERRORS AND 0 WARNINGS WERE FOUND IN 35 FILES
-+A TOTAL OF 296 ERRORS AND 0 WARNINGS WERE FOUND IN 35 FILES
+-A TOTAL OF 293 ERRORS AND 0 WARNINGS WERE FOUND IN 35 FILES
++A TOTAL OF 297 ERRORS AND 0 WARNINGS WERE FOUND IN 35 FILES
  ----------------------------------------------------------------------
 -PHPCBF CAN FIX 231 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 235 OF THESE SNIFF VIOLATIONS AUTOMATICALLY


### PR DESCRIPTION
The language operator `instanceof` should be used instead.