### PR TITLE
Remove usless interface and trait comments

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -206,7 +206,7 @@
                 <element value="~^Created by .+\.\z~i"/>
                 <element value="~^(User|Date|Time): \S+\z~i"/>
                 <element value="~^\S+ [gs]etter\.\z~i"/>
-                <element value="~^Class \S+\z~i"/>
+                <element value="~^(Class|Interface|Trait) \S+\z~i"/>
             </property>
         </properties>
     </rule>

--- a/tests/fixed/forbidden-comments.php
+++ b/tests/fixed/forbidden-comments.php
@@ -24,3 +24,11 @@ class Foo
         return 456;
     }
 }
+
+interface Bar
+{
+}
+
+trait Baz
+{
+}

--- a/tests/input/forbidden-comments.php
+++ b/tests/input/forbidden-comments.php
@@ -40,3 +40,17 @@ class Foo
         return 456;
     }
 }
+
+/**
+ * Interface Bar
+ */
+interface Bar
+{
+}
+
+/**
+ * Trait Baz
+ */
+trait Baz
+{
+}

--- a/tests/php-compatibility.patch
+++ b/tests/php-compatibility.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/expected_report.txt b/tests/expected_report.txt
-index d1fdd9f..50f5de6 100644
+index d1fdd9f..4b5f6e4 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
 @@ -5,21 +5,23 @@ FILE                                                  ERRORS  WARNINGS
@@ -17,8 +17,9 @@ index d1fdd9f..50f5de6 100644
  tests/input/duplicate-assignment-variable.php         1       0
  tests/input/EarlyReturn.php                           6       0
 -tests/input/example-class.php                         34      0
+-tests/input/forbidden-comments.php                    8       0
 +tests/input/example-class.php                         39      0
- tests/input/forbidden-comments.php                    8       0
++tests/input/forbidden-comments.php                    14      0
  tests/input/forbidden-functions.php                   6       0
  tests/input/inline_type_hint_assertions.php           7       0
  tests/input/LowCaseTypes.php                          2       0
@@ -47,10 +48,10 @@ index d1fdd9f..50f5de6 100644
  tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
 -A TOTAL OF 296 ERRORS AND 0 WARNINGS WERE FOUND IN 35 FILES
-+A TOTAL OF 343 ERRORS AND 0 WARNINGS WERE FOUND IN 38 FILES
++A TOTAL OF 349 ERRORS AND 0 WARNINGS WERE FOUND IN 38 FILES
  ----------------------------------------------------------------------
 -PHPCBF CAN FIX 235 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 282 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 284 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  


### PR DESCRIPTION
Tools like PHPStorm also generate these kinda comments. (And we had a code base filled to the brim with them)

I'd love to add tests for this, but i couldn't get the test suite to work locally.