### PR TITLE
Use `NegationOperatorSpacingSniff` to ensure no space before `-`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
     "require": {
         "php": "^7.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-        "slevomat/coding-standard": "^6.0.8",
-        "squizlabs/php_codesniffer": "^3.5.3"
+        "slevomat/coding-standard": "^6.1.4",
+        "squizlabs/php_codesniffer": "^3.5.4"
     },
     "config": {
         "sort-packages": true

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -306,6 +306,8 @@
     <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
     <!-- Forbid weak comparisons -->
     <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
+    <!-- Forbid spacing before the negative operator `-` -->
+    <rule ref="SlevomatCodingStandard.Operators.NegationOperatorSpacing"/>
     <!-- Require the usage of assignment operators, eg `+=`, `.=` when possible -->
     <rule ref="SlevomatCodingStandard.Operators.RequireCombinedAssignmentOperator"/>
     <!-- Require no spacing after spread operator -->

--- a/tests/fixed/negation-operator.php
+++ b/tests/fixed/negation-operator.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+$foo = -1;
+
+if (2 - $foo === 3) {
+    echo -$foo;
+}

--- a/tests/input/negation-operator.php
+++ b/tests/input/negation-operator.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+$foo = - 1;
+
+if (2 - $foo === 3) {
+    echo - $foo;
+}

--- a/tests/php-compatibility.patch
+++ b/tests/php-compatibility.patch
@@ -1,8 +1,8 @@
 diff --git a/tests/expected_report.txt b/tests/expected_report.txt
-index d1fdd9f..a93a3e1 100644
+index d1fdd9f..eab4288 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
-@@ -5,15 +5,16 @@ FILE                                                  ERRORS  WARNINGS
+@@ -5,21 +5,23 @@ FILE                                                  ERRORS  WARNINGS
  ----------------------------------------------------------------------
  tests/input/array_indentation.php                     10      0
  tests/input/assignment-operators.php                  4       0
@@ -21,7 +21,14 @@ index d1fdd9f..a93a3e1 100644
  tests/input/forbidden-comments.php                    8       0
  tests/input/forbidden-functions.php                   6       0
  tests/input/inline_type_hint_assertions.php           7       0
-@@ -33,15 +34,15 @@ tests/input/superfluous-naming.php                    11      0
+ tests/input/LowCaseTypes.php                          2       0
+ tests/input/namespaces-spacing.php                    7       0
+ tests/input/NamingCamelCase.php                       7       0
++tests/input/negation-operator.php                     2       0
+ tests/input/new_with_parentheses.php                  18      0
+ tests/input/not_spacing.php                           8       0
+ tests/input/null_coalesce_operator.php                3       0
+@@ -33,15 +35,15 @@ tests/input/superfluous-naming.php                    11      0
  tests/input/test-case.php                             8       0
  tests/input/trailing_comma_on_array.php               1       0
  tests/input/traits-uses.php                           11      0
@@ -33,10 +40,10 @@ index d1fdd9f..a93a3e1 100644
  tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
 -A TOTAL OF 296 ERRORS AND 0 WARNINGS WERE FOUND IN 35 FILES
-+A TOTAL OF 336 ERRORS AND 0 WARNINGS WERE FOUND IN 36 FILES
++A TOTAL OF 338 ERRORS AND 0 WARNINGS WERE FOUND IN 37 FILES
  ----------------------------------------------------------------------
 -PHPCBF CAN FIX 235 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 275 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 277 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  


### PR DESCRIPTION
The new [`slevomat/coding-standard` version 6.1](https://github.com/slevomat/coding-standard/releases/tag/6.1.0) contains some news sniffs. 

With this, and following PRs, I'd like to suggest some of them.