### PR TITLE
Improve diff while running `test-fix`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test-report: vendor
 test-fix: vendor
 	@if [ $(PHP_74_OR_NEWER) -eq 1 ]; then git apply tests/php-compatibility.patch; fi
 	@cp -R tests/input/ tests/input2/
-	@vendor/bin/phpcbf tests/input2; diff tests/input2 tests/fixed; if [ $$? -ne 0 ]; then rm -rf tests/input2/ && if [ $(PHP_74_OR_NEWER) -eq 1 ]; then git apply -R tests/php-compatibility.patch; fi; exit 1; fi
+	@vendor/bin/phpcbf tests/input2; diff -u tests/input2 tests/fixed; if [ $$? -ne 0 ]; then rm -rf tests/input2/ && if [ $(PHP_74_OR_NEWER) -eq 1 ]; then git apply -R tests/php-compatibility.patch; fi; exit 1; fi
 	@rm -rf tests/input2/ && if [ $(PHP_74_OR_NEWER) -eq 1 ]; then git apply -R tests/php-compatibility.patch; fi
 
 update-compatibility-patch:


### PR DESCRIPTION
Previously, the `make test-fix` outputed something like:

```sh
diff tests/input2/array_indentation.php tests/fixed/array_indentation.php
14c14
< $multiArray = [
---
> $multiArray =[
Only in tests/fixed: single-line-array-spacing.php~
make: *** [test-fix] Error 1
```

Now, using `diff -u`, we have a Git like diff, much easier to understand:

```sh
diff -u tests/input2/array_indentation.php tests/fixed/array_indentation.php
--- tests/input2/array_indentation.php	2020-02-04 22:19:28.000000000 -0300
+++ tests/fixed/array_indentation.php	2020-02-04 22:16:04.000000000 -0300
@@ -11,7 +11,7 @@
     5,
 ];

-$multiArray = [
+$multiArray =[
     '0' => [
         '2' => 2,
         1 => '1',
Only in tests/fixed: single-line-array-spacing.php~
make: *** [test-fix] Error 1
```