### PR TITLE
Introduce Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,11 @@
+# To learn more about this config file, visit: https://dependabot.com/docs/config-file/
+version: 1
+update_configs:
+  - package_manager: "php:composer"
+    directory: "/"
+    update_schedule: "daily"
+    default_reviewers:
+      - "doctrine/coding-standard-approvers"
+    default_labels:
+      - "Dependencies"
+    version_requirement_updates: "increase_versions"

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
     },
     "require": {
         "php": "^7.2",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-        "slevomat/coding-standard": "^6.1.4",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2",
+        "slevomat/coding-standard": "^6.1.5",
         "squizlabs/php_codesniffer": "^3.5.4"
     },
     "config": {


### PR DESCRIPTION
Dependabot (https://dependabot.com) is a bot that will help us keep our
dependencies up to date.

This initial configure will open PRs during workdays and working hours (defined in
https://app.dependabot.com) for our PHP Composer dependencies.

No automerge will be performed for now by Dependabot.