### PR TITLE
Remove PHP 8 from GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -93,7 +93,6 @@ jobs:
           - "7.2"
           - "7.3"
           - "7.4"
-          - "8.0"
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
Since we still don't support PHP 8 and we can't `allow-failures` on that, let's remove it.