### PR TITLE
Adopt PSR-12 for return types

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -354,7 +354,7 @@
     <!-- Require space around colon in return types -->
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing">
         <properties>
-            <property name="spacesCountBeforeColon" value="1"/>
+            <property name="spacesCountBeforeColon" value="0"/>
         </properties>
     </rule>
     <!-- Require types to be written as natively if possible;

--- a/tests/fixed/ControlStructures.php
+++ b/tests/fixed/ControlStructures.php
@@ -15,7 +15,7 @@ class ControlStructures
     /**
      * @return iterable<int>
      */
-    public function varAndIfNoSpaceBetween() : iterable
+    public function varAndIfNoSpaceBetween(): iterable
     {
         $var = 1;
         if (self::VERSION === 0) {
@@ -26,7 +26,7 @@ class ControlStructures
     /**
      * @return iterable<int>
      */
-    public function ifAndYieldSpaceBetween() : iterable
+    public function ifAndYieldSpaceBetween(): iterable
     {
         if (self::VERSION === 0) {
             yield 0;
@@ -38,7 +38,7 @@ class ControlStructures
     /**
      * @return iterable<int>
      */
-    public function ifAndYieldFromSpaceBetween() : iterable
+    public function ifAndYieldFromSpaceBetween(): iterable
     {
         if (self::VERSION === 0) {
             yield 0;
@@ -47,7 +47,7 @@ class ControlStructures
         yield from [];
     }
 
-    public function ifAndThrowSpaceBetween() : void
+    public function ifAndThrowSpaceBetween(): void
     {
         if (self::VERSION === 0) {
             return;
@@ -56,7 +56,7 @@ class ControlStructures
         throw new InvalidArgumentException();
     }
 
-    public function ifAndReturnSpaceBetween() : int
+    public function ifAndReturnSpaceBetween(): int
     {
         if (self::VERSION === 0) {
             return 0;
@@ -65,7 +65,7 @@ class ControlStructures
         return 1;
     }
 
-    public function noSpaceAroundCase() : void
+    public function noSpaceAroundCase(): void
     {
         switch (self::VERSION) {
             case 1:
@@ -79,7 +79,7 @@ class ControlStructures
         }
     }
 
-    public function spaceBelowBlocks() : void
+    public function spaceBelowBlocks(): void
     {
         if (true) {
             echo 1;
@@ -113,7 +113,7 @@ class ControlStructures
         echo 5;
     }
 
-    public function spaceAroundMultilineIfs() : void
+    public function spaceAroundMultilineIfs(): void
     {
         if (
             true

--- a/tests/fixed/EarlyReturn.php
+++ b/tests/fixed/EarlyReturn.php
@@ -6,12 +6,12 @@ namespace Example;
 
 class EarlyReturn
 {
-    public function bar() : bool
+    public function bar(): bool
     {
         return $bar === 'bar';
     }
 
-    public function foo() : ?string
+    public function foo(): ?string
     {
         foreach ($itens as $item) {
             if (! $item->isItem()) {
@@ -24,7 +24,7 @@ class EarlyReturn
         return null;
     }
 
-    public function baz() : string
+    public function baz(): string
     {
         if ($number > 0) {
             return 'Number is grater then 0';
@@ -33,7 +33,7 @@ class EarlyReturn
         exit;
     }
 
-    public function quoox() : bool
+    public function quoox(): bool
     {
         if (true !== 'true') {
             return false;

--- a/tests/fixed/LowCaseTypes.php
+++ b/tests/fixed/LowCaseTypes.php
@@ -6,12 +6,12 @@ namespace Types;
 
 class LowCaseTypes
 {
-    public function stringToInt(string $string) : int
+    public function stringToInt(string $string): int
     {
         return (int) $string;
     }
 
-    public function returnString() : string
+    public function returnString(): string
     {
         return 'foo';
     }

--- a/tests/fixed/NamingCamelCase.php
+++ b/tests/fixed/NamingCamelCase.php
@@ -15,7 +15,7 @@ class NamingCamelCase
     /** @var mixed */
     private $C;
 
-    public function fcn(string $A) : void
+    public function fcn(string $A): void
     {
         $Test = $A;
     }

--- a/tests/fixed/UnusedVariables.php
+++ b/tests/fixed/UnusedVariables.php
@@ -6,11 +6,11 @@ namespace Example;
 
 class UnusedVariables
 {
-    public function unusedInheritedVariablePassedToClosure() : void
+    public function unusedInheritedVariablePassedToClosure(): void
     {
         $foo = 'foo';
 
-        $bar = static function () : int {
+        $bar = static function (): int {
             return 1;
         };
     }

--- a/tests/fixed/UselessConditions.php
+++ b/tests/fixed/UselessConditions.php
@@ -9,27 +9,27 @@ use function strpos;
 
 class UselessConditions
 {
-    public function uselessCondition() : bool
+    public function uselessCondition(): bool
     {
         return $foo === 'foo';
     }
 
-    public function uselessIfCondition() : bool
+    public function uselessIfCondition(): bool
     {
         return $bar === 'bar';
     }
 
-    public function uselessNegativeCondition() : bool
+    public function uselessNegativeCondition(): bool
     {
         return $foo === 'foo';
     }
 
-    public function uselessIfNegativeCondition() : bool
+    public function uselessIfNegativeCondition(): bool
     {
         return $bar !== 'bar';
     }
 
-    public function unecessaryIfMethodForEarlyReturn() : bool
+    public function unecessaryIfMethodForEarlyReturn(): bool
     {
         if ($bar === 'bar') {
             return false;
@@ -42,7 +42,7 @@ class UselessConditions
         return $baz !== 'baz';
     }
 
-    public function uselessIfConditionWithParameter(bool $bool) : bool
+    public function uselessIfConditionWithParameter(bool $bool): bool
     {
         if ($bool) {
             return false;
@@ -51,7 +51,7 @@ class UselessConditions
         return true;
     }
 
-    public function uselessIfConditionWithBoolMethod() : bool
+    public function uselessIfConditionWithBoolMethod(): bool
     {
         if ($this->isTrue()) {
             return false;
@@ -60,22 +60,22 @@ class UselessConditions
         return true;
     }
 
-    public function uselessIfConditionWithComplexIf() : bool
+    public function uselessIfConditionWithComplexIf(): bool
     {
         return $bar === 'bar' && $foo === 'foo' && $baz !== 'quox';
     }
 
-    public function uselessIfConditionWithEvenMoreComplexIf() : bool
+    public function uselessIfConditionWithEvenMoreComplexIf(): bool
     {
         return $bar === 'bar' || $foo === 'foo' || $baz !== 'quox';
     }
 
-    public function uselessIfConditionWithComplexCondition() : bool
+    public function uselessIfConditionWithComplexCondition(): bool
     {
         return $bar !== 'bar' && $foo !== 'foo' && $baz === 'quox';
     }
 
-    public function uselessIfConditionWithTernary() : bool
+    public function uselessIfConditionWithTernary(): bool
     {
         if ($this->isTrue()) {
             return $this->isTrulyTrue() ? true : false;
@@ -84,7 +84,7 @@ class UselessConditions
         return false;
     }
 
-    public function necessaryIfConditionWithMethodCall() : bool
+    public function necessaryIfConditionWithMethodCall(): bool
     {
         if ($this->shouldBeQueued()) {
             $this->queue();
@@ -95,7 +95,7 @@ class UselessConditions
         return false;
     }
 
-    public function nullShouldNotBeTreatedAsFalse() : ?bool
+    public function nullShouldNotBeTreatedAsFalse(): ?bool
     {
         if (! $this->isAdmin) {
             return null;
@@ -104,17 +104,17 @@ class UselessConditions
         return true;
     }
 
-    public function uselessTernary() : bool
+    public function uselessTernary(): bool
     {
         return $foo !== 'bar';
     }
 
-    public function uselessTernaryWithParameter(bool $condition) : bool
+    public function uselessTernaryWithParameter(bool $condition): bool
     {
         return $condition ? true : false;
     }
 
-    public function uselessTernaryWithMethod() : bool
+    public function uselessTernaryWithMethod(): bool
     {
         return $this->isFalse() ? true : false;
     }
@@ -122,12 +122,12 @@ class UselessConditions
     /**
      * @param string[] $words
      */
-    public function uselessTernaryCheck(array $words) : bool
+    public function uselessTernaryCheck(array $words): bool
     {
         return count($words) < 1;
     }
 
-    public function necessaryTernary() : int
+    public function necessaryTernary(): int
     {
         return strpos('foo', 'This is foo and bar') !== false ? 1 : 0;
     }

--- a/tests/fixed/class-references.php
+++ b/tests/fixed/class-references.php
@@ -11,7 +11,7 @@ class Bar extends Foo
     /**
      * @return string[]
      */
-    public function names() : iterable
+    public function names(): iterable
     {
         yield self::class;
         yield self::class;

--- a/tests/fixed/doc-comment-spacing.php
+++ b/tests/fixed/doc-comment-spacing.php
@@ -12,7 +12,7 @@ class Test
     /**
      * Description
      */
-    public function a() : void
+    public function a(): void
     {
     }
 
@@ -21,7 +21,7 @@ class Test
      * More Description
      * Even More Description
      */
-    public function b() : void
+    public function b(): void
     {
     }
 
@@ -34,7 +34,7 @@ class Test
      *
      * @throws FooException
      */
-    public function c(iterable $foo) : void
+    public function c(iterable $foo): void
     {
     }
 
@@ -64,7 +64,7 @@ class Test
      * @throws FooException
      * @throws BarException
      */
-    public function d(iterable $foo, iterable $bar) : iterable
+    public function d(iterable $foo, iterable $bar): iterable
     {
     }
 }

--- a/tests/fixed/example-class.php
+++ b/tests/fixed/example-class.php
@@ -46,7 +46,7 @@ class Example implements IteratorAggregate
     /**
      * Description
      */
-    public function getFoo() : ?int
+    public function getFoo(): ?int
     {
         return $this->foo;
     }
@@ -54,14 +54,14 @@ class Example implements IteratorAggregate
     /**
      * @return iterable
      */
-    public function getIterator() : array
+    public function getIterator(): array
     {
         assert($this->bar !== null);
 
         return new ArrayIterator($this->bar);
     }
 
-    public function isBaz() : bool
+    public function isBaz(): bool
     {
         [$foo, $bar, $baz] = $this->bar;
 
@@ -71,7 +71,7 @@ class Example implements IteratorAggregate
     /**
      * @throws InvalidArgumentException if this example cannot baz.
      */
-    public function mangleBar(int $length) : void
+    public function mangleBar(int $length): void
     {
         if (! $this->baz) {
             throw new InvalidArgumentException();
@@ -80,12 +80,12 @@ class Example implements IteratorAggregate
         $this->bar = (string) $this->baxBax ?? substr($this->bar, stringLength($this->bar - $length));
     }
 
-    public static function getMinorVersion() : int
+    public static function getMinorVersion(): int
     {
         return self::VERSION;
     }
 
-    public static function getTestCase() : TestCase
+    public static function getTestCase(): TestCase
     {
         return new TestCase();
     }

--- a/tests/fixed/forbidden-comments.php
+++ b/tests/fixed/forbidden-comments.php
@@ -11,7 +11,7 @@ class Foo
         echo 'Hello';
     }
 
-    public function getBar() : int
+    public function getBar(): int
     {
         return 123;
     }
@@ -19,7 +19,7 @@ class Foo
     /**
      * Very important getter.
      */
-    public function getBaz() : int
+    public function getBaz(): int
     {
         return 456;
     }

--- a/tests/fixed/return_type_on_closures.php
+++ b/tests/fixed/return_type_on_closures.php
@@ -2,28 +2,19 @@
 
 declare(strict_types=1);
 
-static function () : void {
+static function (): void {
 }
 
-static function () : void {
+static function (): void {
 }
 
-static function () : void {
+static function (): void {
 }
 
-static function () : void {
+static function (): void {
 }
 
-static function () : void {
-}
-
-static function (
-    int $a,
-    int $c,
-    int $d,
-    int $e,
-    int $b
-) : void {
+static function (): void {
 }
 
 static function (
@@ -32,7 +23,7 @@ static function (
     int $d,
     int $e,
     int $b
-) : void {
+): void {
 }
 
 static function (
@@ -41,7 +32,7 @@ static function (
     int $d,
     int $e,
     int $b
-) : void {
+): void {
 }
 
 static function (
@@ -50,7 +41,7 @@ static function (
     int $d,
     int $e,
     int $b
-) : void {
+): void {
 }
 
 static function (
@@ -59,5 +50,14 @@ static function (
     int $d,
     int $e,
     int $b
-) : void {
+): void {
+}
+
+static function (
+    int $a,
+    int $c,
+    int $d,
+    int $e,
+    int $b
+): void {
 }

--- a/tests/fixed/return_type_on_methods.php
+++ b/tests/fixed/return_type_on_methods.php
@@ -6,23 +6,23 @@ namespace Blah;
 
 class Test
 {
-    public function a() : void
+    public function a(): void
     {
     }
 
-    public function b() : void
+    public function b(): void
     {
     }
 
-    public function c() : void
+    public function c(): void
     {
     }
 
-    public function d() : void
+    public function d(): void
     {
     }
 
-    public function e() : void
+    public function e(): void
     {
     }
 
@@ -32,7 +32,7 @@ class Test
         int $d,
         int $e,
         int $b
-    ) : void {
+    ): void {
     }
 
     public function g(
@@ -41,7 +41,7 @@ class Test
         int $d,
         int $e,
         int $b
-    ) : void {
+    ): void {
     }
 
     public function h(
@@ -50,7 +50,7 @@ class Test
         int $d,
         int $e,
         int $b
-    ) : void {
+    ): void {
     }
 
     public function i(
@@ -59,7 +59,7 @@ class Test
         int $d,
         int $e,
         int $b
-    ) : void {
+    ): void {
     }
 
     public function j(
@@ -68,6 +68,6 @@ class Test
         int $d,
         int $e,
         int $b
-    ) : void {
+    ): void {
     }
 }

--- a/tests/fixed/spread-operator.php
+++ b/tests/fixed/spread-operator.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-static function (...$x) : void {
+static function (...$x): void {
 }
-static function (int ...$x) : void {
+static function (int ...$x): void {
 }
-static function ($x, ...$y) : void {
+static function ($x, ...$y): void {
 }
-static function (int $x, int ...$y) : void {
+static function (int $x, int ...$y): void {
 }
 
 foo(...$x);

--- a/tests/fixed/static-closures.php
+++ b/tests/fixed/static-closures.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-(static function () : void {
+(static function (): void {
     echo 'Hello';
 })();
 
 new class {
     public function __construct()
     {
-        (function () : iterable {
+        (function (): iterable {
             yield $this;
         })();
     }

--- a/tests/fixed/test-case.php
+++ b/tests/fixed/test-case.php
@@ -15,14 +15,14 @@ final class TestCase extends BaseTestCase
      * @beforeClass
      * @afterClass
      */
-    public static function doStuff() : void
+    public static function doStuff(): void
     {
     }
 
     /**
      * @before
      */
-    public function createDependencies() : void
+    public function createDependencies(): void
     {
     }
 
@@ -32,7 +32,7 @@ final class TestCase extends BaseTestCase
      * @test
      * @covers MyClass::test
      */
-    public function methodShouldDoStuff() : void
+    public function methodShouldDoStuff(): void
     {
     }
 }

--- a/tests/fixed/type-hints.php
+++ b/tests/fixed/type-hints.php
@@ -17,7 +17,7 @@ class TraversableTypeHints
      *
      * @return Traversable
      */
-    public function get(Iterator $iterator) : Traversable
+    public function get(Iterator $iterator): Traversable
     {
         return $this->parameter;
     }

--- a/tests/input/ControlStructures.php
+++ b/tests/input/ControlStructures.php
@@ -15,7 +15,7 @@ class ControlStructures
     /**
      * @return iterable<int>
      */
-    public function varAndIfNoSpaceBetween() : iterable
+    public function varAndIfNoSpaceBetween(): iterable
     {
         $var = 1;
         if (self::VERSION === 0) {
@@ -26,7 +26,7 @@ class ControlStructures
     /**
      * @return iterable<int>
      */
-    public function ifAndYieldSpaceBetween() : iterable
+    public function ifAndYieldSpaceBetween(): iterable
     {
         if (self::VERSION === 0) {
             yield 0;
@@ -37,7 +37,7 @@ class ControlStructures
     /**
      * @return iterable<int>
      */
-    public function ifAndYieldFromSpaceBetween() : iterable
+    public function ifAndYieldFromSpaceBetween(): iterable
     {
         if (self::VERSION === 0) {
             yield 0;
@@ -45,7 +45,7 @@ class ControlStructures
         yield from [];
     }
 
-    public function ifAndThrowSpaceBetween() : void
+    public function ifAndThrowSpaceBetween(): void
     {
         if (self::VERSION === 0) {
             return;
@@ -53,7 +53,7 @@ class ControlStructures
         throw new InvalidArgumentException();
     }
 
-    public function ifAndReturnSpaceBetween() : int
+    public function ifAndReturnSpaceBetween(): int
     {
         if (self::VERSION === 0) {
             return 0;
@@ -62,7 +62,7 @@ class ControlStructures
         return 1;
     }
 
-    public function noSpaceAroundCase() : void
+    public function noSpaceAroundCase(): void
     {
         switch (self::VERSION) {
             case 1:
@@ -76,7 +76,7 @@ class ControlStructures
         }
     }
 
-    public function spaceBelowBlocks() : void
+    public function spaceBelowBlocks(): void
     {
         if (true) {
             echo 1;
@@ -103,7 +103,7 @@ class ControlStructures
         echo 5;
     }
 
-    public function spaceAroundMultilineIfs() : void
+    public function spaceAroundMultilineIfs(): void
     {
         if (true
         && false) {

--- a/tests/input/EarlyReturn.php
+++ b/tests/input/EarlyReturn.php
@@ -6,7 +6,7 @@ namespace Example;
 
 class EarlyReturn
 {
-    public function bar() : bool
+    public function bar(): bool
     {
         if ($bar === 'bar') {
             return true;
@@ -15,7 +15,7 @@ class EarlyReturn
         }
     }
 
-    public function foo() : ?string
+    public function foo(): ?string
     {
         foreach ($itens as $item) {
             if (! ($item->isItem())) {
@@ -28,7 +28,7 @@ class EarlyReturn
         return null;
     }
 
-    public function baz() : string
+    public function baz(): string
     {
         if ($number > 0) {
             return 'Number is grater then 0';
@@ -37,7 +37,7 @@ class EarlyReturn
         }
     }
 
-    public function quoox() : bool
+    public function quoox(): bool
     {
         if (true === 'true') {
             if (false === false) {

--- a/tests/input/LowCaseTypes.php
+++ b/tests/input/LowCaseTypes.php
@@ -6,12 +6,12 @@ namespace Types;
 
 class LowCaseTypes
 {
-    public function stringToInt(String $string) : int
+    public function stringToInt(String $string): int
     {
         return (int) $string;
     }
 
-    public function returnString() : String
+    public function returnString(): String
     {
         return 'foo';
     }

--- a/tests/input/NamingCamelCase.php
+++ b/tests/input/NamingCamelCase.php
@@ -15,7 +15,7 @@ class NamingCamelCase
     /** @var mixed */
     private $C;
 
-    public function fcn(string $A) : void
+    public function fcn(string $A): void
     {
         $Test = $A;
     }

--- a/tests/input/UnusedVariables.php
+++ b/tests/input/UnusedVariables.php
@@ -6,11 +6,11 @@ namespace Example;
 
 class UnusedVariables
 {
-    public function unusedInheritedVariablePassedToClosure() : void
+    public function unusedInheritedVariablePassedToClosure(): void
     {
         $foo = 'foo';
 
-        $bar = static function () use ($foo) : int {
+        $bar = static function () use ($foo): int {
             return 1;
         };
     }

--- a/tests/input/UselessConditions.php
+++ b/tests/input/UselessConditions.php
@@ -9,7 +9,7 @@ use function strpos;
 
 class UselessConditions
 {
-    public function uselessCondition() : bool
+    public function uselessCondition(): bool
     {
         if ($foo === 'foo') {
             return true;
@@ -18,7 +18,7 @@ class UselessConditions
         }
     }
 
-    public function uselessIfCondition() : bool
+    public function uselessIfCondition(): bool
     {
         if ($bar === 'bar') {
             return true;
@@ -27,7 +27,7 @@ class UselessConditions
         return false;
     }
 
-    public function uselessNegativeCondition() : bool
+    public function uselessNegativeCondition(): bool
     {
         if ($foo !== 'foo') {
             return false;
@@ -36,7 +36,7 @@ class UselessConditions
         }
     }
 
-    public function uselessIfNegativeCondition() : bool
+    public function uselessIfNegativeCondition(): bool
     {
         if ($bar === 'bar') {
             return false;
@@ -45,7 +45,7 @@ class UselessConditions
         return true;
     }
 
-    public function unecessaryIfMethodForEarlyReturn() : bool
+    public function unecessaryIfMethodForEarlyReturn(): bool
     {
         if ($bar === 'bar') {
             return false;
@@ -62,7 +62,7 @@ class UselessConditions
         return true;
     }
 
-    public function uselessIfConditionWithParameter(bool $bool) : bool
+    public function uselessIfConditionWithParameter(bool $bool): bool
     {
         if ($bool) {
             return false;
@@ -71,7 +71,7 @@ class UselessConditions
         return true;
     }
 
-    public function uselessIfConditionWithBoolMethod() : bool
+    public function uselessIfConditionWithBoolMethod(): bool
     {
         if ($this->isTrue()) {
             return false;
@@ -80,7 +80,7 @@ class UselessConditions
         return true;
     }
 
-    public function uselessIfConditionWithComplexIf() : bool
+    public function uselessIfConditionWithComplexIf(): bool
     {
         if ($bar === 'bar' && $foo === 'foo' && $baz !== 'quox') {
             return true;
@@ -89,7 +89,7 @@ class UselessConditions
         }
     }
 
-    public function uselessIfConditionWithEvenMoreComplexIf() : bool
+    public function uselessIfConditionWithEvenMoreComplexIf(): bool
     {
         if ($bar === 'bar' || $foo === 'foo' || $baz !== 'quox') {
             return true;
@@ -98,7 +98,7 @@ class UselessConditions
         }
     }
 
-    public function uselessIfConditionWithComplexCondition() : bool
+    public function uselessIfConditionWithComplexCondition(): bool
     {
         if ($bar === 'bar' || $foo === 'foo' || $baz !== 'quox') {
             return false;
@@ -107,7 +107,7 @@ class UselessConditions
         return true;
     }
 
-    public function uselessIfConditionWithTernary() : bool
+    public function uselessIfConditionWithTernary(): bool
     {
         if ($this->isTrue()) {
             return $this->isTrulyTrue() ? true : false;
@@ -116,7 +116,7 @@ class UselessConditions
         }
     }
 
-    public function necessaryIfConditionWithMethodCall() : bool
+    public function necessaryIfConditionWithMethodCall(): bool
     {
         if ($this->shouldBeQueued()) {
             $this->queue();
@@ -127,7 +127,7 @@ class UselessConditions
         return false;
     }
 
-    public function nullShouldNotBeTreatedAsFalse() : ?bool
+    public function nullShouldNotBeTreatedAsFalse(): ?bool
     {
         if (! $this->isAdmin) {
             return null;
@@ -136,17 +136,17 @@ class UselessConditions
         return true;
     }
 
-    public function uselessTernary() : bool
+    public function uselessTernary(): bool
     {
         return $foo !== 'bar' ? true : false;
     }
 
-    public function uselessTernaryWithParameter(bool $condition) : bool
+    public function uselessTernaryWithParameter(bool $condition): bool
     {
         return $condition ? true : false;
     }
 
-    public function uselessTernaryWithMethod() : bool
+    public function uselessTernaryWithMethod(): bool
     {
         return $this->isFalse() ? true : false;
     }
@@ -154,12 +154,12 @@ class UselessConditions
     /**
      * @param string[] $words
      */
-    public function uselessTernaryCheck(array $words) : bool
+    public function uselessTernaryCheck(array $words): bool
     {
         return count($words) >= 1 ? false : true;
     }
 
-    public function necessaryTernary() : int
+    public function necessaryTernary(): int
     {
         return strpos('foo', 'This is foo and bar') !== false ? 1 : 0;
     }

--- a/tests/input/class-references.php
+++ b/tests/input/class-references.php
@@ -11,7 +11,7 @@ class Bar extends Foo
     /**
      * @return string[]
      */
-    public function names() : iterable
+    public function names(): iterable
     {
         yield __CLASS__;
         yield get_class();

--- a/tests/input/doc-comment-spacing.php
+++ b/tests/input/doc-comment-spacing.php
@@ -14,7 +14,7 @@ class Test
      * Description
      *
      */
-    public function a() : void
+    public function a(): void
     {
     }
 
@@ -23,7 +23,7 @@ class Test
      * More Description
      * Even More Description
      */
-    public function b() : void
+    public function b(): void
     {
     }
 
@@ -34,7 +34,7 @@ class Test
      * @throws FooException
      * @param int[] $foo
      */
-    public function c(iterable $foo) : void
+    public function c(iterable $foo): void
     {
     }
 
@@ -60,7 +60,7 @@ class Test
      * @see  other
      *
      */
-    public function d(iterable $foo, iterable $bar) : iterable
+    public function d(iterable $foo, iterable $bar): iterable
     {
     }
 }

--- a/tests/input/example-class.php
+++ b/tests/input/example-class.php
@@ -43,7 +43,7 @@ class Example implements \IteratorAggregate
      * Description
      * @return int|null
      */
-    public function getFoo(): ? int
+    public function getFoo() : ? int
     {
         return $this->foo;
     }
@@ -52,13 +52,13 @@ class Example implements \IteratorAggregate
     /**
      * @return iterable
      */
-    public function getIterator():array
+    public function getIterator() :array
     {
         assert($this->bar !== null);
         return new \ArrayIterator($this->bar);
     }
 
-    public function isBaz() : bool
+    public function isBaz(): bool
     {
         list($foo, $bar, $baz) = $this->bar;
 
@@ -68,7 +68,7 @@ class Example implements \IteratorAggregate
     /**
      * @throws InvalidArgumentException if this example cannot baz.
      */
-    public function mangleBar(int $length) : void
+    public function mangleBar(int $length): void
     {
         if (!$this->baz) {
             throw new \InvalidArgumentException();
@@ -77,14 +77,14 @@ class Example implements \IteratorAggregate
         $this->bar = (string) $this->baxBax ?? \substr($this->bar, stringLength($this->bar - $length));
     }
 
-    public static function getMinorVersion() : int
+    public static function getMinorVersion(): int
     {
         $version = self::VERSION;
 
         return $version;
     }
 
-    public static function getTestCase() : TestCase
+    public static function getTestCase(): TestCase
     {
         return new TestCase();
     }

--- a/tests/input/forbidden-comments.php
+++ b/tests/input/forbidden-comments.php
@@ -27,7 +27,7 @@ class Foo
     /**
      * Bar getter.
      */
-    public function getBar() : int
+    public function getBar(): int
     {
         return 123;
     }
@@ -35,7 +35,7 @@ class Foo
     /**
      * Very important getter.
      */
-    public function getBaz() : int
+    public function getBaz(): int
     {
         return 456;
     }

--- a/tests/input/return_type_on_closures.php
+++ b/tests/input/return_type_on_closures.php
@@ -6,7 +6,7 @@ static function ():void
 {
 }
 
-static function (): void
+static function () : void
 {
 }
 
@@ -28,7 +28,7 @@ static function (
     int $d,
     int $e,
     int $b
-):void {
+) :void {
 }
 
 static function (
@@ -55,7 +55,7 @@ static function (
     int $d,
     int $e,
     int $b
-): void {
+) : void {
 }
 
 static function (
@@ -64,5 +64,5 @@ static function (
     int $d,
     int $e,
     int $b
-):   void {
+) :   void {
 }

--- a/tests/input/return_type_on_methods.php
+++ b/tests/input/return_type_on_methods.php
@@ -6,11 +6,11 @@ namespace Blah;
 
 class Test
 {
-    public function a():void
+    public function a() :void
     {
     }
 
-    public function b(): void
+    public function b() : void
     {
     }
 
@@ -32,7 +32,7 @@ class Test
         int $d,
         int $e,
         int $b
-    ):void {
+    ) :void {
     }
 
     public function g(
@@ -59,7 +59,7 @@ class Test
         int $d,
         int $e,
         int $b
-    ): void {
+    ) : void {
     }
 
     public function j(

--- a/tests/input/spread-operator.php
+++ b/tests/input/spread-operator.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-static function (... $x) : void {
+static function (... $x): void {
 }
-static function (int ... $x) : void {
+static function (int ... $x): void {
 }
-static function ($x, ... $y) : void {
+static function ($x, ... $y): void {
 }
-static function (int $x, int ... $y) : void {
+static function (int $x, int ... $y): void {
 }
 
 foo(... $x);

--- a/tests/input/static-closures.php
+++ b/tests/input/static-closures.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-(function () : void {
+(function (): void {
     echo 'Hello';
 })();
 
 new class {
     public function __construct()
     {
-        (function () : iterable {
+        (function (): iterable {
             yield $this;
         })();
     }

--- a/tests/input/test-case.php
+++ b/tests/input/test-case.php
@@ -17,7 +17,7 @@ final class TestCase extends BaseTestCase
      * @beforeClass
      * @afterClass
      */
-    static public function doStuff(): void
+    static public function doStuff() : void
     {
     }
 

--- a/tests/input/type-hints.php
+++ b/tests/input/type-hints.php
@@ -17,7 +17,7 @@ class TraversableTypeHints
      *
      * @return Traversable
      */
-    public function get(Iterator $iterator) : Traversable
+    public function get(Iterator $iterator): Traversable
     {
         return $this->parameter;
     }


### PR DESCRIPTION
[PSR-12](https://www.php-fig.org/psr/psr-12) is an extension of the PSR-2 set of rules
that aims to standardize the code style.

Doctrine, so far, hasn't adopted 100% off it, and this PR proposes to start to migrate our rules
to PSR-12.

The first one is the `return types`. As described under the section [4.5](https://www.php-fig.org/psr/psr-12/#45-method-and-function-arguments),

> The colon and declaration MUST be on the same line as the argument list closing parenthesis with no spaces between the two characters.

where the two characters are the closing parenthesis `)` and colon `:`.

For context on why this was voted in the past, see #9.