### PR TITLE
Adopt PSR-12 for imports statements separation

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -301,7 +301,7 @@
         <properties>
             <property name="linesCountAfterLastUse" value="1"/>
             <property name="linesCountBeforeFirstUse" value="1"/>
-            <property name="linesCountBetweenUseTypes" value="0"/>
+            <property name="linesCountBetweenUseTypes" value="1"/>
         </properties>
     </rule>
     <!-- Forbid useless alias for classes, constants and functions -->

--- a/tests/fixed/ControlStructures.php
+++ b/tests/fixed/ControlStructures.php
@@ -6,6 +6,7 @@ namespace ControlStructures;
 
 use InvalidArgumentException;
 use Throwable;
+
 use const PHP_VERSION;
 
 class ControlStructures

--- a/tests/fixed/example-class.php
+++ b/tests/fixed/example-class.php
@@ -9,9 +9,11 @@ use Doctrine\Sniffs\Spacing\ControlStructureSniff;
 use Fancy\TestCase;
 use InvalidArgumentException;
 use IteratorAggregate;
+
 use function assert;
 use function strlen as stringLength;
 use function substr;
+
 use const PHP_MINOR_VERSION;
 use const PHP_RELEASE_VERSION as PHP_PATCH_VERSION;
 use const PHP_VERSION;

--- a/tests/fixed/namespaces-spacing.php
+++ b/tests/fixed/namespaces-spacing.php
@@ -7,8 +7,10 @@ namespace Foo;
 use DateInterval;
 use DateTimeImmutable;
 use DateTimeZone;
+
 use function strrev;
 use function time;
+
 use const DATE_RFC3339;
 
 strrev(

--- a/tests/fixed/use-ordering.php
+++ b/tests/fixed/use-ordering.php
@@ -6,7 +6,9 @@ namespace Foo;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+
 use function sprintf;
+
 use const PHP_EOL;
 
 echo sprintf('Current date and time is %s', (new DateTimeImmutable())->format(DateTimeInterface::ATOM)) . PHP_EOL;

--- a/tests/input/ControlStructures.php
+++ b/tests/input/ControlStructures.php
@@ -6,6 +6,7 @@ namespace ControlStructures;
 
 use InvalidArgumentException;
 use Throwable;
+
 use const PHP_VERSION;
 
 class ControlStructures

--- a/tests/input/example-class.php
+++ b/tests/input/example-class.php
@@ -5,9 +5,13 @@ declare(strict_types = 1);
 namespace Example;
 
 use Throwable;
+
 use function strlen as stringLength;
+
 use Fancy\TestCase as TestCase;
+
 use const PHP_RELEASE_VERSION as PHP_PATCH_VERSION;
+
 use Doctrine\Sniffs\Spacing\ControlStructureSniff;
 
 /**

--- a/tests/input/namespaces-spacing.php
+++ b/tests/input/namespaces-spacing.php
@@ -5,10 +5,8 @@ namespace Foo;
 use DateInterval;
 use DateTimeImmutable;
 use DateTimeZone;
-
 use function strrev;
 use function time;
-
 use const DATE_RFC3339;
 strrev(
     (new DateTimeImmutable('@' . time(), new DateTimeZone('UTC')))

--- a/tests/input/use-ordering.php
+++ b/tests/input/use-ordering.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Foo;
 
 use function sprintf;
+
 use DateTimeImmutable;
+
 use const PHP_EOL;
+
 use DateTimeInterface;
 
 echo sprintf('Current date and time is %s', (new DateTimeImmutable())->format(DateTimeInterface::ATOM)) . PHP_EOL;


### PR DESCRIPTION
[PSR-12](https://www.php-fig.org/psr/psr-12) is an extension of the PSR-2 set of rules
that aims to standardize the code style.

As per PSR-12, under the [item 3](https://www.php-fig.org/psr/psr-12/#3-declare-statements-namespace-and-import-statements):

> The header of a PHP file may consist of a number of different blocks. If present,
> each of the blocks below MUST be separated by a single blank line, and MUST NOT
> contain a blank line. Each block MUST be in the order listed below, although
> blocks that are not relevant may be omitted.

For context on why this was voted in the past, see #9.