### PR TITLE
Ensure that Typed Properties are spaced correctly

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -380,6 +380,7 @@
             </property>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHintSpacing"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
         <properties>
             <property name="traversableTypeHints" type="array">

--- a/tests/fixed/PropertyTypeHintSpacing.php
+++ b/tests/fixed/PropertyTypeHintSpacing.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spacing;
+
+final class PropertyTypeHintSpacing
+{
+    public bool $boolPropertyWithDefaultValue = false;
+    public string $stringProperty;
+    public int $intProperty;
+    public ?string $nullableString = null;
+}

--- a/tests/input/PropertyTypeHintSpacing.php
+++ b/tests/input/PropertyTypeHintSpacing.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spacing;
+
+final class PropertyTypeHintSpacing
+{
+    public bool $boolPropertyWithDefaultValue  = false;
+    public string  $stringProperty;
+    public  int $intProperty;
+    public ? string $nullableString = null;
+}

--- a/tests/php-compatibility.patch
+++ b/tests/php-compatibility.patch
@@ -1,8 +1,8 @@
 diff --git a/tests/expected_report.txt b/tests/expected_report.txt
-index d1fdd9f..4b5f6e4 100644
+index d1fdd9f..577922e 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
-@@ -5,21 +5,23 @@ FILE                                                  ERRORS  WARNINGS
+@@ -5,43 +5,47 @@ FILE                                                  ERRORS  WARNINGS
  ----------------------------------------------------------------------
  tests/input/array_indentation.php                     10      0
  tests/input/assignment-operators.php                  4       0
@@ -29,7 +29,8 @@ index d1fdd9f..4b5f6e4 100644
  tests/input/new_with_parentheses.php                  18      0
  tests/input/not_spacing.php                           8       0
  tests/input/null_coalesce_operator.php                3       0
-@@ -27,21 +29,22 @@ tests/input/optimized-functions.php                   1       0
+ tests/input/optimized-functions.php                   1       0
++tests/input/PropertyTypeHintSpacing.php               6       0
  tests/input/return_type_on_closures.php               21      0
  tests/input/return_type_on_methods.php                17      0
  tests/input/semicolon_spacing.php                     3       0
@@ -48,18 +49,18 @@ index d1fdd9f..4b5f6e4 100644
  tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
 -A TOTAL OF 296 ERRORS AND 0 WARNINGS WERE FOUND IN 35 FILES
-+A TOTAL OF 349 ERRORS AND 0 WARNINGS WERE FOUND IN 38 FILES
++A TOTAL OF 355 ERRORS AND 0 WARNINGS WERE FOUND IN 39 FILES
  ----------------------------------------------------------------------
 -PHPCBF CAN FIX 235 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 284 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 290 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  
 diff --git a/tests/fixed/example-class.php b/tests/fixed/example-class.php
-index 59148a3..eb019d5 100644
+index dbec9cb..dca22ed 100644
 --- a/tests/fixed/example-class.php
 +++ b/tests/fixed/example-class.php
-@@ -23,14 +23,12 @@ class Example implements IteratorAggregate
+@@ -25,14 +25,12 @@ class Example implements IteratorAggregate
  {
      private const VERSION = PHP_VERSION - (PHP_MINOR_VERSION * 100) - PHP_PATCH_VERSION;
  
@@ -78,7 +79,7 @@ index 59148a3..eb019d5 100644
      /** @var ControlStructureSniff|int|string|null */
      private $baxBax;
 diff --git a/tests/fixed/type-hints.php b/tests/fixed/type-hints.php
-index a1b1827..fb7d406 100644
+index 0e952fc..9824fb0 100644
 --- a/tests/fixed/type-hints.php
 +++ b/tests/fixed/type-hints.php
 @@ -10,7 +10,7 @@ use Traversable;


### PR DESCRIPTION
This new rule checks for things like:

- one space between the typehint and the property name
- one space between the typehint and the property's modifiers
- no space between the nullability symbol and the typehint

This rule does not check for:

- How many lines the typed properties are separated by
- If two consecutive properties have default values, the `=` sign will be aligned

This also falls under the PSR-12, by [the item 4.3](https://www.php-fig.org/psr/psr-12/#43-properties-and-constants):

> There MUST be a space between type declaration and property name.