### PR TITLE
Add rule to check multiline method call indentation

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -105,6 +105,12 @@
     <rule ref="Generic.PHP.SAPIUsage"/>
     <!-- Forbid comments starting with # -->
     <rule ref="PEAR.Commenting.InlineComment"/>
+    <!-- Force proper indentation for multi-line object calls -->
+    <rule ref="PEAR.WhiteSpace.ObjectOperatorIndent">
+        <properties>
+            <property name="multilevel" value="true" />
+        </properties>
+    </rule>
     <!-- Disallow else if in favor of elseif -->
     <rule ref="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed">
         <type>error</type>

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -18,6 +18,7 @@ tests/input/forbidden-comments.php                    8       0
 tests/input/forbidden-functions.php                   6       0
 tests/input/inline_type_hint_assertions.php           7       0
 tests/input/LowCaseTypes.php                          2       0
+tests/input/multiline-call-indentation.php            1       0
 tests/input/namespaces-spacing.php                    7       0
 tests/input/NamingCamelCase.php                       7       0
 tests/input/new_with_parentheses.php                  18      0
@@ -39,9 +40,9 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 296 ERRORS AND 0 WARNINGS WERE FOUND IN 35 FILES
+A TOTAL OF 297 ERRORS AND 0 WARNINGS WERE FOUND IN 36 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 235 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 236 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/multiline-call-indentation.php
+++ b/tests/fixed/multiline-call-indentation.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+$object = new stdClass();
+
+$object->method();
+
+$object->method()->nested();
+
+$object
+    ->method()
+    ->nested();
+
+$object
+    ->method()
+        ->doubleNested()
+        ->stillNested()
+            ->nestedTooFar()
+        ->evenMoreLevels()
+    ->notNested()
+        ->nestedCorrectly();

--- a/tests/input/multiline-call-indentation.php
+++ b/tests/input/multiline-call-indentation.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+$object = new stdClass();
+
+$object->method();
+
+$object->method()->nested();
+
+$object
+    ->method()
+    ->nested();
+
+$object
+    ->method()
+        ->doubleNested()
+        ->stillNested()
+                ->nestedTooFar()
+        ->evenMoreLevels()
+    ->notNested()
+        ->nestedCorrectly();

--- a/tests/php-compatibility.patch
+++ b/tests/php-compatibility.patch
@@ -23,6 +23,7 @@ index d1fdd9f..577922e 100644
  tests/input/forbidden-functions.php                   6       0
  tests/input/inline_type_hint_assertions.php           7       0
  tests/input/LowCaseTypes.php                          2       0
+ tests/input/multiline-call-indentation.php            1       0
  tests/input/namespaces-spacing.php                    7       0
  tests/input/NamingCamelCase.php                       7       0
 +tests/input/negation-operator.php                     2       0
@@ -48,11 +49,11 @@ index d1fdd9f..577922e 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 296 ERRORS AND 0 WARNINGS WERE FOUND IN 35 FILES
-+A TOTAL OF 355 ERRORS AND 0 WARNINGS WERE FOUND IN 39 FILES
+-A TOTAL OF 297 ERRORS AND 0 WARNINGS WERE FOUND IN 36 FILES
++A TOTAL OF 356 ERRORS AND 0 WARNINGS WERE FOUND IN 40 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 235 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 290 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 236 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 291 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  


### PR DESCRIPTION
This new rule enforces consistent indentation for multiline methods. The input and fixed files do a better job at explaining the rule than I could.

One note is that the sniff currently does not allow to decrease the indent by multiple levels. For example, this code is not valid:

```php
$test
    ->doSomething()
        ->doSomethingElse()
            ->doYetAnotherThing()
    ->goAllTheWayBack();
```

In this case, the last line would be indented by 4 additional spaces, since the rule forbids increasing or decreasing by more than one level. Please let me know if any of the Doctrine projects contain code that would contain code that allows for such use-cases.