### PR TITLE
Ensure that spacing around `cases` are consistent

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -240,6 +240,9 @@
     <!-- Require consistent spacing for jump statements -->
     <rule ref="SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing">
         <properties>
+            <property name="linesCountBeforeWhenFirstInCaseOrDefault" value="0"/>
+            <property name="linesCountAfterWhenLastInCaseOrDefault" value="1"/>
+            <property name="linesCountAfterWhenLastInLastCaseOrDefault" value="0"/>
             <property name="tokensToCheck" type="array">
                 <element value="T_RETURN" />
                 <element value="T_THROW" />

--- a/tests/fixed/ControlStructures.php
+++ b/tests/fixed/ControlStructures.php
@@ -128,4 +128,21 @@ class ControlStructures
             echo 2;
         }
     }
+
+    public function spacingAroundCasesWithBreakAndReturn(): void
+    {
+        switch (true) {
+            case 1:
+                throw new InvalidArgumentException();
+
+            case 2:
+                return;
+
+            case 3:
+                break;
+
+            case 4:
+                echo 1;
+        }
+    }
 }

--- a/tests/input/ControlStructures.php
+++ b/tests/input/ControlStructures.php
@@ -115,4 +115,28 @@ class ControlStructures
             echo 2;
         }
     }
+
+    public function spacingAroundCasesWithBreakAndReturn(): void
+    {
+        switch (true) {
+
+            case 1:
+
+                throw new InvalidArgumentException();
+
+            case 2:
+
+                return;
+
+
+            case 3:
+
+                break;
+
+            case 4:
+
+                echo 1;
+
+        }
+    }
 }

--- a/tests/php-compatibility.patch
+++ b/tests/php-compatibility.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/expected_report.txt b/tests/expected_report.txt
-index 1e809f9..4776284 100644
+index 1e809f9..490fcbd 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
 @@ -5,44 +5,48 @@ FILE                                                  ERRORS  WARNINGS
@@ -12,7 +12,8 @@ index 1e809f9..4776284 100644
 +tests/input/concatenation_spacing.php                 49      0
  tests/input/constants-no-lsb.php                      2       0
  tests/input/constants-var.php                         4       0
- tests/input/ControlStructures.php                     17      0
+-tests/input/ControlStructures.php                     17      0
++tests/input/ControlStructures.php                     27      0
  tests/input/doc-comment-spacing.php                   10      0
  tests/input/duplicate-assignment-variable.php         1       0
  tests/input/EarlyReturn.php                           6       0
@@ -52,10 +53,10 @@ index 1e809f9..4776284 100644
  tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
 -A TOTAL OF 297 ERRORS AND 0 WARNINGS WERE FOUND IN 36 FILES
-+A TOTAL OF 361 ERRORS AND 0 WARNINGS WERE FOUND IN 40 FILES
++A TOTAL OF 371 ERRORS AND 0 WARNINGS WERE FOUND IN 40 FILES
  ----------------------------------------------------------------------
 -PHPCBF CAN FIX 236 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 296 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 306 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  


### PR DESCRIPTION
As reported via slevomat/coding-standard#867, in case that a switch
with cases returning or breaking, the `JumpStatementsSpacing` sniff
wasn't handling it properly.

These 3 new options ensure that this sniff handles this case as well.

Requested by @morozov via https://github.com/doctrine/coding-standard/pull/167#issuecomment-606056629.