### PR TITLE
Add rule forbidding more than one constant declared per statement

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -121,6 +121,8 @@
     </rule>
     <!-- Forbid LSB for constants (static::FOO) -->
     <rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants"/>
+    <!-- Forbid more than one constant declared per statement -->
+    <rule ref="SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition"/>
     <!-- Forbid empty lines around type declarations -->
     <rule ref="SlevomatCodingStandard.Classes.EmptyLinesAroundClassBraces">
         <properties>

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -8,7 +8,7 @@ tests/input/assignment-operators.php                  4       0
 tests/input/class-references.php                      10      0
 tests/input/concatenation_spacing.php                 24      0
 tests/input/constants-no-lsb.php                      2       0
-tests/input/constants-var.php                         4       0
+tests/input/constants-var.php                         6       0
 tests/input/ControlStructures.php                     17      0
 tests/input/doc-comment-spacing.php                   10      0
 tests/input/duplicate-assignment-variable.php         1       0
@@ -40,9 +40,9 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 297 ERRORS AND 0 WARNINGS WERE FOUND IN 36 FILES
+A TOTAL OF 299 ERRORS AND 0 WARNINGS WERE FOUND IN 36 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 236 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 238 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/constants-var.php
+++ b/tests/fixed/constants-var.php
@@ -6,7 +6,13 @@ namespace ConstantsVar;
 
 const FOO = 123;
 
+const BAR_1 = 1;
+const BAR_1 = 2;
+
 class Bar
 {
     public const BAZ = 456;
+
+    protected const PROPERTY_1 = '1';
+    protected const PROPERTY_2 = '2';
 }

--- a/tests/input/constants-var.php
+++ b/tests/input/constants-var.php
@@ -7,8 +7,12 @@ namespace ConstantsVar;
 /** @var int */
 const FOO = 123;
 
+const BAR_1 = 1, BAR_1 = 2;
+
 class Bar
 {
     /** @var int */
     public const BAZ = 456;
+
+    protected const PROPERTY_1 = '1', PROPERTY_2 = '2';
 }

--- a/tests/php-compatibility.patch
+++ b/tests/php-compatibility.patch
@@ -11,7 +11,7 @@ index 1e809f9..490fcbd 100644
 -tests/input/concatenation_spacing.php                 24      0
 +tests/input/concatenation_spacing.php                 49      0
  tests/input/constants-no-lsb.php                      2       0
- tests/input/constants-var.php                         4       0
+ tests/input/constants-var.php                         6       0
 -tests/input/ControlStructures.php                     17      0
 +tests/input/ControlStructures.php                     27      0
  tests/input/doc-comment-spacing.php                   10      0
@@ -52,11 +52,11 @@ index 1e809f9..490fcbd 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 297 ERRORS AND 0 WARNINGS WERE FOUND IN 36 FILES
-+A TOTAL OF 371 ERRORS AND 0 WARNINGS WERE FOUND IN 40 FILES
+-A TOTAL OF 299 ERRORS AND 0 WARNINGS WERE FOUND IN 36 FILES
++A TOTAL OF 373 ERRORS AND 0 WARNINGS WERE FOUND IN 40 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 236 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 306 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 238 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 308 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  


### PR DESCRIPTION
Although PSR only have this rule suggested to class properties, we
enforce it for constants as well.