### PR TITLE
Add rule to ensure Arrow Functions declaration format

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -267,6 +267,14 @@
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
     <!-- Require using Throwable instead of Exception -->
     <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"/>
+    <!-- Ensure Arrow Functions declaration format -->
+    <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration">
+        <properties>
+            <property name="spacesCountAfterKeyword" value="1"/>
+            <property name="spacesCountBeforeArrow" value="1"/>
+            <property name="spacesCountAfterArrow" value="1"/>
+        </properties>
+    </rule>
     <!-- Require closures not referencing $this be static -->
     <rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>
     <!-- Forbid unused variables passed to closures via `use` -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -4,6 +4,7 @@ PHP CODE SNIFFER REPORT SUMMARY
 FILE                                                  ERRORS  WARNINGS
 ----------------------------------------------------------------------
 tests/input/array_indentation.php                     10      0
+tests/input/arrow-functions-format.php                10      0
 tests/input/assignment-operators.php                  4       0
 tests/input/class-references.php                      10      0
 tests/input/concatenation_spacing.php                 24      0
@@ -40,9 +41,9 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 299 ERRORS AND 0 WARNINGS WERE FOUND IN 36 FILES
+A TOTAL OF 309 ERRORS AND 0 WARNINGS WERE FOUND IN 37 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 238 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 248 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/arrow-functions-format.php
+++ b/tests/fixed/arrow-functions-format.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+$missingStatic = static fn ($a, $b) => $a + $b;
+
+$uselessParentheses = static fn ($x) => $x + $y;
+
+$withReturnType = static fn (): int => 1 + 2;
+
+$withTypesInArguments = static fn (int $a, int $b): int => $a + $b;
+
+$spacing = static fn (int $x) => $x * 2;
+
+$nested = static fn ($x) => static fn ($y) => $x * $y + $z;
+
+$returningObject = static fn () => new stdClass();
+
+$multiLineArrowFunctions = Collection::from([1, 2])
+    ->map(
+        static fn (int $v): int => $v * 2
+    )
+    ->reduce(
+        static fn (int $tmp, int $v): int => $tmp + $v
+    );
+
+$thisIsNotAnArrowFunction = [$this->fn => 'value'];
+
+$arrayWithArrowFunctions = [
+    'true' => static fn () => true,
+    'false' => static fn () => false,
+];
+
+$singleLineArrayReturn = Collection::map(
+    static fn () => [1, 2]
+);
+
+$wrongMultiLineArrayReturn = Collection::map(
+    static fn () => [
+        1,
+        2,
+    ]
+);

--- a/tests/input/arrow-functions-format.php
+++ b/tests/input/arrow-functions-format.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+$missingStatic = fn ($a, $b) => $a + $b;
+
+$uselessParentheses = static fn ($x) => ($x + $y);
+
+$withReturnType = static fn () : int => 1 + 2;
+
+$withTypesInArguments = static fn (int $a , int $b): int => $a + $b;
+
+$spacing = static fn(int $x)  =>  $x * 2;
+
+$nested = static fn ($x)=>static fn ($y) => $x * $y + $z;
+
+$returningObject = static fn () => new stdClass();
+
+$multiLineArrowFunctions = Collection::from([1, 2])
+    ->map(
+        static fn (int $v): int => $v * 2
+    )
+    ->reduce(
+        static fn (int $tmp, int $v): int => $tmp + $v
+    );
+
+$thisIsNotAnArrowFunction = [$this->fn => 'value'];
+
+$arrayWithArrowFunctions = [
+    'true' => static fn () => true,
+    'false' => static fn () => false,
+];
+
+$singleLineArrayReturn = Collection::map(
+    static fn () => [1, 2]
+);
+
+$wrongMultiLineArrayReturn = Collection::map(
+    static fn () => [
+        1, 2
+    ]
+);

--- a/tests/php-compatibility.patch
+++ b/tests/php-compatibility.patch
@@ -5,6 +5,7 @@ index 1e809f9..490fcbd 100644
 @@ -5,44 +5,48 @@ FILE                                                  ERRORS  WARNINGS
  ----------------------------------------------------------------------
  tests/input/array_indentation.php                     10      0
+ tests/input/arrow-functions-format.php                10      0
  tests/input/assignment-operators.php                  4       0
 +tests/input/binary_operators.php                      9       0
  tests/input/class-references.php                      10      0
@@ -52,11 +53,11 @@ index 1e809f9..490fcbd 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 299 ERRORS AND 0 WARNINGS WERE FOUND IN 36 FILES
-+A TOTAL OF 373 ERRORS AND 0 WARNINGS WERE FOUND IN 40 FILES
+-A TOTAL OF 309 ERRORS AND 0 WARNINGS WERE FOUND IN 37 FILES
++A TOTAL OF 383 ERRORS AND 0 WARNINGS WERE FOUND IN 41 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 238 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 308 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 248 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 318 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  


### PR DESCRIPTION
This new rule enforces format for already declared `arrow functions` (this sniff
does not convert anonymous function to arrow functions).

-------

Note for reviewers: the idea of having `1 space` set for `spacesCountAfterKeyword` is that we follow the current standards for function calls.

Pool on Twitter for reference: https://twitter.com/carusogabriel/status/1251576089497010177