### PR TITLE
Remove dead sniffs autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,6 @@
         {"name": "Benjamin Eberlei", "email": "kontakt@beberlei.de"},
         {"name": "Steve Müller", "email": "st.mueller@dzh-online.de"}
     ],
-    "autoload": {
-       "psr-4": {
-           "Doctrine\\Sniffs\\": "lib/Doctrine/Sniffs"
-       }
-    },
     "require": {
         "php": "^7.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2",


### PR DESCRIPTION
Not sure why this is in here, looks like an old relic that was forgotten to remove. Also causes issue with `roave/better-reflection` when using the `MakeLocatorForComposerJsonAndInstalledJson` locator factory that assumes any defines autoload paths to exist.

Mutually exclusive with: #177 