### PR TITLE
Fix warnings on Travis CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-dist: xenial
-sudo: false
+dist: bionic
 language: php
+os: linux
 
 php:
   - 7.2


### PR DESCRIPTION
Warnings from https://travis-ci.org/github/doctrine/coding-standard/builds/676955885/config:

```
root: deprecated key sudo (The key `sudo` has no effect anymore.)
root: deprecated key sudo (The key `sudo` has no effect anymore.)
root: missing os, using the default linux
```