### PR TITLE
Lock version of squizlabs/php_codesniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2",
         "slevomat/coding-standard": "^6.2.0",
-        "squizlabs/php_codesniffer": "^3.5.4"
+        "squizlabs/php_codesniffer": "3.5.0 - 3.5.4"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
The latest version of `squizlabs/php_codesniffer` has a regression, and
we don't want to pull those.

See https://github.com/doctrine/coding-standard/pull/173#pullrequestreview-397004830.