### PR TITLE
Disable PSR2.Classes.ClassDeclaration.ExtendsLine and ImplementsLine

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -8,6 +8,10 @@
 
     <!-- Import PSR-12 coding standard (base) -->
     <rule ref="PSR12">
+        <!-- Allow multiline extends in class declarations -->
+        <exclude name="PSR2.Classes.ClassDeclaration.ExtendsLine" />
+        <!-- Allow multiline implements in class declarations -->
+        <exclude name="PSR2.Classes.ClassDeclaration.ImplementsLine" />
         <!-- checked by SlevomatCodingStandard.Namespaces.UseSpacing -->
         <exclude name="PSR2.Namespaces.UseDeclaration.SpaceAfterLastUse"/>
         <exclude name="PSR12.Files.FileHeader"/>

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -6,6 +6,7 @@ FILE                                                  ERRORS  WARNINGS
 tests/input/array_indentation.php                     10      0
 tests/input/assignment-operators.php                  4       0
 tests/input/class-references.php                      10      0
+tests/input/classes.php                               3       0
 tests/input/concatenation_spacing.php                 24      0
 tests/input/constants-no-lsb.php                      2       0
 tests/input/constants-var.php                         6       0

--- a/tests/input/classes.php
+++ b/tests/input/classes.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Classes;
+
+use Countable;
+
+class A
+{
+}
+
+/** Allow multiline class declarations */
+final class ComplexClassDeclarationSoItNeedsToBeSplitAcrossMultipleLines
+    extends A
+    implements Countable
+{
+    public function count(): int
+    {
+        return 0;
+    }
+}


### PR DESCRIPTION
I'm using SlevomatCodingStandard.Files.LineLength that limits me to keep my lines at 120 symbols.

This change would allow such code:

```php
final class ComplexClassDeclarationSoItNeedsToBeSplitAcrossMultipleLines
    extends A
    implements Countable
```

this is not currently possible in compliance with this CS.

The more complex example:
```php
final class ComplexClassDeclarationSoItNeedsToBeSplitAcrossMultipleLines extends A implements Countable, InterfaceA, InterfaceB, InterfaceC
```

vs

```php
final class ComplexClassDeclarationSoItNeedsToBeSplitAcrossMultipleLines
    extends A
    implements Countable, InterfaceA, InterfaceB, InterfaceC
```