### PR TITLE
Update tests expectations based on bugfix in dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "require": {
         "php": "^7.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2",
-        "slevomat/coding-standard": "^6.2.0",
-        "squizlabs/php_codesniffer": "^3.5.4"
+        "slevomat/coding-standard": "^6.3.8",
+        "squizlabs/php_codesniffer": "^3.5.5"
     },
     "config": {
         "sort-packages": true

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -10,7 +10,7 @@ tests/input/class-references.php                      10      0
 tests/input/concatenation_spacing.php                 24      0
 tests/input/constants-no-lsb.php                      2       0
 tests/input/constants-var.php                         6       0
-tests/input/ControlStructures.php                     17      0
+tests/input/ControlStructures.php                     18      0
 tests/input/doc-comment-spacing.php                   10      0
 tests/input/duplicate-assignment-variable.php         1       0
 tests/input/EarlyReturn.php                           6       0
@@ -41,9 +41,9 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 309 ERRORS AND 0 WARNINGS WERE FOUND IN 37 FILES
+A TOTAL OF 310 ERRORS AND 0 WARNINGS WERE FOUND IN 37 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 248 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 249 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/ControlStructures.php
+++ b/tests/fixed/ControlStructures.php
@@ -19,9 +19,11 @@ class ControlStructures
     public function varAndIfNoSpaceBetween(): iterable
     {
         $var = 1;
-        if (self::VERSION === 0) {
-            yield 0;
+        if (self::VERSION !== 0) {
+            return;
         }
+
+        yield 0;
     }
 
     /**

--- a/tests/php-compatibility.patch
+++ b/tests/php-compatibility.patch
@@ -13,8 +13,8 @@ index 1e809f9..490fcbd 100644
 +tests/input/concatenation_spacing.php                 49      0
  tests/input/constants-no-lsb.php                      2       0
  tests/input/constants-var.php                         6       0
--tests/input/ControlStructures.php                     17      0
-+tests/input/ControlStructures.php                     27      0
+-tests/input/ControlStructures.php                     18      0
++tests/input/ControlStructures.php                     28      0
  tests/input/doc-comment-spacing.php                   10      0
  tests/input/duplicate-assignment-variable.php         1       0
  tests/input/EarlyReturn.php                           6       0
@@ -53,11 +53,11 @@ index 1e809f9..490fcbd 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 309 ERRORS AND 0 WARNINGS WERE FOUND IN 37 FILES
-+A TOTAL OF 383 ERRORS AND 0 WARNINGS WERE FOUND IN 41 FILES
+-A TOTAL OF 310 ERRORS AND 0 WARNINGS WERE FOUND IN 37 FILES
++A TOTAL OF 384 ERRORS AND 0 WARNINGS WERE FOUND IN 41 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 248 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 318 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 249 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 319 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  


### PR DESCRIPTION
`slevomat/coding-standard` has fixed one bug that we need to reflect on our tests.

After this and #192, we should be ready to release the [`v8`](https://github.com/doctrine/coding-standard/milestone/11).