### PR TITLE
Slevomat ReturnTypeHintSpacing: remove default spacesCountBeforeColon configuration

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -368,11 +368,7 @@
     <!-- Require one space between typehint and variable, require no space between nullability sign and typehint -->
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
     <!-- Require space around colon in return types -->
-    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing">
-        <properties>
-            <property name="spacesCountBeforeColon" value="0"/>
-        </properties>
-    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
     <!-- Require types to be written as natively if possible;
          require iterable types to specify phpDoc with their content;
          forbid useless/duplicated information in phpDoc -->


### PR DESCRIPTION
This was changed to zero here: https://github.com/doctrine/coding-standard/pull/163

But this is the default so no need for the override: https://github.com/slevomat/coding-standard/blob/c4e287879af90a2f56b1b516deaba707858c9a24/SlevomatCodingStandard/Sniffs/TypeHints/ReturnTypeHintSpacingSniff.php#L35