### PR TITLE
Remove PSR12.Properties.ConstantVisibility in favor of slevomat

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -17,6 +17,8 @@
         <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterVariadic"/>
         <!-- checked by SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing -->
         <exclude name="PSR12.Functions.ReturnTypeDeclaration"/>
+        <!-- checked by SlevomatCodingStandard.Classes.ClassConstantVisibility -->
+        <exclude name="PSR12.Properties.ConstantVisibility"/>
         <!-- checked by SlevomatCodingStandard.Classes.TraitUseSpacing -->
         <exclude name="PSR12.Traits.UseDeclaration"/>
         <!-- checked by SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing.WhitespaceAfterNullabilitySymbol -->


### PR DESCRIPTION
Isn't this already checked by slevomat?

Does the one cover cases that the other does not? Then if yes.. shouldn't the `PSR12.Properties.ConstantVisibility` be turned to an `error`.. because currently it is a warning