### PR TITLE
Raise Squiz.PHP.NonExecutableCode to error

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -504,7 +504,9 @@
     <!-- Require PHP function calls in lowercase -->
     <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
     <!-- Forbid dead code -->
-    <rule ref="Squiz.PHP.NonExecutableCode"/>
+    <rule ref="Squiz.PHP.NonExecutableCode">
+        <type>error</type>
+    </rule>
     <!-- Forbid `$this` inside static function -->
     <rule ref="Squiz.Scope.StaticThisUsage"/>
     <!-- Force whitespace before and after concatenation -->


### PR DESCRIPTION
Not sure if this was on purpose.

This rules is intent to throw a warning and not an error.