### PR TITLE
Fix exit code handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test: test-report test-fix
 
 test-report: vendor
 	@if [ $(PHP_74_OR_NEWER) -eq 1 ]; then git apply tests/php-compatibility.patch; fi
-	@vendor/bin/phpcs `find tests/input/* | sort` --report=summary --report-file=phpcs.log; diff -u tests/expected_report.txt phpcs.log; if [ $$? -ne 0 ] && [ $(PHP_74_OR_NEWER) -eq 1 ]; then git apply -R tests/php-compatibility.patch; exit 1; fi
+	@vendor/bin/phpcs `find tests/input/* | sort` --report=summary --report-file=phpcs.log; diff -u tests/expected_report.txt phpcs.log; if [ $$? -ne 0 ]; then if [ $(PHP_74_OR_NEWER) -eq 1 ]; then git apply -R tests/php-compatibility.patch; fi; exit 1; fi
 	@if [ $(PHP_74_OR_NEWER) -eq 1 ]; then git apply -R tests/php-compatibility.patch; fi
 
 test-fix: vendor

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -6,29 +6,33 @@ FILE                                                  ERRORS  WARNINGS
 tests/input/array_indentation.php                     10      0
 tests/input/arrow-functions-format.php                10      0
 tests/input/assignment-operators.php                  4       0
+tests/input/binary_operators.php                      9       0
 tests/input/class-references.php                      10      0
-tests/input/concatenation_spacing.php                 24      0
+tests/input/concatenation_spacing.php                 49      0
 tests/input/constants-no-lsb.php                      2       0
 tests/input/constants-var.php                         6       0
-tests/input/ControlStructures.php                     18      0
+tests/input/ControlStructures.php                     28      0
 tests/input/doc-comment-spacing.php                   10      0
 tests/input/duplicate-assignment-variable.php         1       0
 tests/input/EarlyReturn.php                           6       0
-tests/input/example-class.php                         34      0
-tests/input/forbidden-comments.php                    8       0
+tests/input/example-class.php                         36      0
+tests/input/forbidden-comments.php                    14      0
 tests/input/forbidden-functions.php                   6       0
 tests/input/inline_type_hint_assertions.php           7       0
 tests/input/LowCaseTypes.php                          2       0
 tests/input/namespaces-spacing.php                    7       0
 tests/input/NamingCamelCase.php                       7       0
+tests/input/negation-operator.php                     2       0
 tests/input/new_with_parentheses.php                  18      0
 tests/input/not_spacing.php                           8       0
 tests/input/null_coalesce_equal_operator.php          1       0
 tests/input/null_coalesce_operator.php                3       0
 tests/input/optimized-functions.php                   1       0
+tests/input/PropertyTypeHintSpacing.php               6       0
 tests/input/return_type_on_closures.php               21      0
 tests/input/return_type_on_methods.php                17      0
 tests/input/semicolon_spacing.php                     3       0
+tests/input/single-line-array-spacing.php             5       0
 tests/input/spread-operator.php                       6       0
 tests/input/static-closures.php                       1       0
 tests/input/superfluous-naming.php                    11      0
@@ -41,9 +45,9 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 310 ERRORS AND 0 WARNINGS WERE FOUND IN 37 FILES
+A TOTAL OF 375 ERRORS AND 0 WARNINGS WERE FOUND IN 41 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 249 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 310 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/php-compatibility.patch
+++ b/tests/php-compatibility.patch
@@ -1,48 +1,29 @@
 diff --git a/tests/expected_report.txt b/tests/expected_report.txt
-index 1e809f9..490fcbd 100644
+index fd5432c..233e24d 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
-@@ -5,44 +5,48 @@ FILE                                                  ERRORS  WARNINGS
- ----------------------------------------------------------------------
- tests/input/array_indentation.php                     10      0
- tests/input/arrow-functions-format.php                10      0
- tests/input/assignment-operators.php                  4       0
-+tests/input/binary_operators.php                      9       0
- tests/input/class-references.php                      10      0
--tests/input/concatenation_spacing.php                 24      0
-+tests/input/concatenation_spacing.php                 49      0
- tests/input/constants-no-lsb.php                      2       0
- tests/input/constants-var.php                         6       0
--tests/input/ControlStructures.php                     18      0
-+tests/input/ControlStructures.php                     28      0
+@@ -15,7 +15,7 @@ tests/input/ControlStructures.php                     28      0
  tests/input/doc-comment-spacing.php                   10      0
  tests/input/duplicate-assignment-variable.php         1       0
  tests/input/EarlyReturn.php                           6       0
--tests/input/example-class.php                         34      0
--tests/input/forbidden-comments.php                    8       0
+-tests/input/example-class.php                         36      0
 +tests/input/example-class.php                         39      0
-+tests/input/forbidden-comments.php                    14      0
+ tests/input/forbidden-comments.php                    14      0
  tests/input/forbidden-functions.php                   6       0
  tests/input/inline_type_hint_assertions.php           7       0
- tests/input/LowCaseTypes.php                          2       0
+@@ -23,9 +23,9 @@ tests/input/LowCaseTypes.php                          2       0
  tests/input/namespaces-spacing.php                    7       0
  tests/input/NamingCamelCase.php                       7       0
+ tests/input/negation-operator.php                     2       0
 -tests/input/new_with_parentheses.php                  18      0
-+tests/input/negation-operator.php                     2       0
 +tests/input/new_with_parentheses.php                  19      0
  tests/input/not_spacing.php                           8       0
 -tests/input/null_coalesce_equal_operator.php          1       0
 +tests/input/null_coalesce_equal_operator.php          5       0
  tests/input/null_coalesce_operator.php                3       0
  tests/input/optimized-functions.php                   1       0
-+tests/input/PropertyTypeHintSpacing.php               6       0
- tests/input/return_type_on_closures.php               21      0
- tests/input/return_type_on_methods.php                17      0
- tests/input/semicolon_spacing.php                     3       0
-+tests/input/single-line-array-spacing.php             5       0
- tests/input/spread-operator.php                       6       0
- tests/input/static-closures.php                       1       0
- tests/input/superfluous-naming.php                    11      0
+ tests/input/PropertyTypeHintSpacing.php               6       0
+@@ -39,15 +39,15 @@ tests/input/superfluous-naming.php                    11      0
  tests/input/test-case.php                             8       0
  tests/input/trailing_comma_on_array.php               1       0
  tests/input/traits-uses.php                           11      0
@@ -53,10 +34,10 @@ index 1e809f9..490fcbd 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 310 ERRORS AND 0 WARNINGS WERE FOUND IN 37 FILES
+-A TOTAL OF 375 ERRORS AND 0 WARNINGS WERE FOUND IN 41 FILES
 +A TOTAL OF 384 ERRORS AND 0 WARNINGS WERE FOUND IN 41 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 249 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 310 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 319 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  


### PR DESCRIPTION
The exit code was only being checked on PHP 7.4+, which is completely wrong.

This makes the checks behave consistently across all supported versions, updating the expected reports accordingly.

Fixes: https://github.com/doctrine/coding-standard/issues/209