### PR TITLE
Refine rules

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -102,6 +102,8 @@
     <rule ref="Generic.PHP.LowerCaseType"/>
     <!-- Forbid `php_sapi_name()` function -->
     <rule ref="Generic.PHP.SAPIUsage"/>
+    <!-- Require there be no space between increment/decrement operator and its operand -->
+    <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
     <!-- Forbid comments starting with # -->
     <rule ref="PEAR.Commenting.InlineComment"/>
     <!-- Disallow else if in favor of elseif -->
@@ -529,8 +531,6 @@
             <property name="spacingAfterLast" value="0"/>
         </properties>
     </rule>
-    <!-- Require there be no space between increment/decrement operator and its operand -->
-    <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
     <!-- Require space after language constructs -->
     <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
     <!-- Require space around logical operators -->

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -21,8 +21,6 @@
         <exclude name="PSR12.Traits.UseDeclaration"/>
         <!-- checked by SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing.WhitespaceAfterNullabilitySymbol -->
         <exclude name="PSR12.Functions.NullableTypeDeclaration.WhitespaceFound"/>
-        <!-- checked by PSR12.ControlStructures.ControlStructureSpacing -->
-        <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace"/>
     </rule>
 
     <!-- Force array element indentation with 4 spaces -->

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -521,8 +521,6 @@
     </rule>
     <!-- Forbid braces around string in `echo` -->
     <rule ref="Squiz.Strings.EchoedStrings"/>
-    <!-- Forbid spaces in type casts -->
-    <rule ref="Squiz.WhiteSpace.CastSpacing"/>
     <!-- Forbid blank line after function opening brace -->
     <rule ref="Squiz.WhiteSpace.FunctionOpeningBraceSpace"/>
     <!-- Require 1 line before and after function, except at the top and bottom -->


### PR DESCRIPTION
# Squiz.WhiteSpace.CastSpacing

This is included in PSR-12.

```bash
vendor/bin/phpcs --standard=PSR12 -e
Squiz (15 sniffs)
-----------------
  Squiz.Classes.ValidClassName
  Squiz.ControlStructures.ControlSignature
  Squiz.ControlStructures.ForEachLoopDeclaration
  Squiz.ControlStructures.ForLoopDeclaration
  Squiz.ControlStructures.LowercaseDeclaration
  Squiz.Functions.FunctionDeclaration
  Squiz.Functions.FunctionDeclarationArgumentSpacing
  Squiz.Functions.LowercaseFunctionKeywords
  Squiz.Functions.MultiLineFunctionDeclaration
  Squiz.Scope.MethodScope
  Squiz.WhiteSpace.CastSpacing
  Squiz.WhiteSpace.ControlStructureSpacing
  Squiz.WhiteSpace.ScopeClosingBrace
  Squiz.WhiteSpace.ScopeKeywordSpacing
  Squiz.WhiteSpace.SuperfluousWhitespace
```

# PSR2.ControlStructures.ControlStructureSpacing

This is not included in PSR-12.

```bash
vendor/bin/phpcs --standard=PSR12 -e
PSR2 (9 sniffs)
---------------
  PSR2.Classes.ClassDeclaration
  PSR2.Classes.PropertyDeclaration
  PSR2.ControlStructures.ElseIfDeclaration
  PSR2.ControlStructures.SwitchDeclaration
  PSR2.Files.ClosingTag
  PSR2.Files.EndFileNewline
  PSR2.Methods.FunctionCallSignature
  PSR2.Methods.FunctionClosingBrace
  PSR2.Methods.MethodDeclaration
```
