### PR TITLE
Still works on PHP 7.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -90,6 +90,7 @@ jobs:
     strategy:
       matrix:
         php-version:
+          - "7.1"
           - "7.2"
           - "7.3"
           - "7.4"
@@ -125,7 +126,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.2"
+          - "7.1"
           - "7.4"
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         {"name": "Steve Müller", "email": "st.mueller@dzh-online.de"}
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.1 || ^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
         "slevomat/coding-standard": "^6.3.9",
         "squizlabs/php_codesniffer": "^3.5.5"


### PR DESCRIPTION
Restricting the 8.1 branch to 7.1 is an artificial constraint, the code works on 7.1 just fine.

https://github.com/doctrine/coding-standard/pull/127 removed 7.1 support, but slevomat/coding-standard reintroduced 7.1 support with https://github.com/slevomat/coding-standard/commit/b26cb5cb3a0ae2b64a174b9cc98cab70c92e2f8e#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34