### PR TITLE
Cherry pick constraint relaxation to dealerdirect/phpcodersniffer-composer-installer plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": "^7.1",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0 | ^0.6.2 | ^0.7",
         "slevomat/coding-standard": "^5.0",
         "squizlabs/php_codesniffer": "^3.4.0"
     },

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -24,7 +24,7 @@ tests/input/optimized-functions.php                   1       0
 tests/input/return_type_on_closures.php               21      0
 tests/input/return_type_on_methods.php                17      0
 tests/input/semicolon_spacing.php                     3       0
-tests/input/spread-operator.php                       6       0
+tests/input/spread-operator.php                       10      0
 tests/input/static-closures.php                       1       0
 tests/input/superfluous-naming.php                    11      0
 tests/input/test-case.php                             8       0
@@ -34,9 +34,9 @@ tests/input/UnusedVariables.php                       1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 258 ERRORS AND 0 WARNINGS WERE FOUND IN 30 FILES
+A TOTAL OF 262 ERRORS AND 0 WARNINGS WERE FOUND IN 30 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 210 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 214 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 


### PR DESCRIPTION
Cherry pick https://github.com/doctrine/coding-standard/commit/637003febec655f1b27f4301b44bf2264be57434 downstream to avoid Composer 2 installation failures.