### PR TITLE
Removed UnusedPrivateElements

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -144,8 +144,6 @@
             <property name="linesCountBetweenUses" value="0"/>
         </properties>
     </rule>
-    <!-- Forbid dead code -->
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
     <!-- Forbid prefix and suffix "Abstract" for abstract classes -->
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
     <!-- Forbid prefix and suffix "Exception" for exception classes -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -21,7 +21,7 @@ tests/input/forbidden-functions.php                   6       0
 tests/input/inline_type_hint_assertions.php           7       0
 tests/input/LowCaseTypes.php                          2       0
 tests/input/namespaces-spacing.php                    7       0
-tests/input/NamingCamelCase.php                       7       0
+tests/input/NamingCamelCase.php                       6       0
 tests/input/negation-operator.php                     2       0
 tests/input/new_with_parentheses.php                  18      0
 tests/input/not_spacing.php                           8       0
@@ -45,7 +45,7 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 375 ERRORS AND 0 WARNINGS WERE FOUND IN 41 FILES
+A TOTAL OF 374 ERRORS AND 0 WARNINGS WERE FOUND IN 41 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 310 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------


### PR DESCRIPTION
It has been removed from Slevomat: https://github.com/slevomat/coding-standard/commit/bcbf756f05979a05b1ae2b7a8ed6796f060cfa83