### PR TITLE
Add RequireOneLineDocComment sniff

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -419,6 +419,8 @@
     </rule>
     <!-- Forbid useless @var for constants -->
     <rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"/>
+    <!-- Require One Line Doc Comment where there's only 1 annotation present -->
+    <rule ref="SlevomatCodingStandard.Commenting.RequireOneLineDocComment"/>
     <!-- Forbid useless phpDocs for functions -->
     <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment">
         <properties>

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -12,10 +12,10 @@ tests/input/concatenation_spacing.php                 49      0
 tests/input/constants-no-lsb.php                      2       0
 tests/input/constants-var.php                         6       0
 tests/input/ControlStructures.php                     28      0
-tests/input/doc-comment-spacing.php                   10      0
+tests/input/doc-comment-spacing.php                   11      0
 tests/input/duplicate-assignment-variable.php         1       0
 tests/input/EarlyReturn.php                           6       0
-tests/input/example-class.php                         36      0
+tests/input/example-class.php                         38      0
 tests/input/forbidden-comments.php                    14      0
 tests/input/forbidden-functions.php                   6       0
 tests/input/inline_type_hint_assertions.php           7       0
@@ -45,9 +45,9 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 374 ERRORS AND 0 WARNINGS WERE FOUND IN 41 FILES
+A TOTAL OF 377 ERRORS AND 0 WARNINGS WERE FOUND IN 41 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 310 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 313 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/ControlStructures.php
+++ b/tests/fixed/ControlStructures.php
@@ -13,9 +13,7 @@ class ControlStructures
 {
     private const VERSION = PHP_VERSION;
 
-    /**
-     * @return iterable<int>
-     */
+    /** @return iterable<int> */
     public function varAndIfNoSpaceBetween(): iterable
     {
         $var = 1;
@@ -26,9 +24,7 @@ class ControlStructures
         yield 0;
     }
 
-    /**
-     * @return iterable<int>
-     */
+    /** @return iterable<int> */
     public function ifAndYieldSpaceBetween(): iterable
     {
         if (self::VERSION === 0) {
@@ -38,9 +34,7 @@ class ControlStructures
         yield 1;
     }
 
-    /**
-     * @return iterable<int>
-     */
+    /** @return iterable<int> */
     public function ifAndYieldFromSpaceBetween(): iterable
     {
         if (self::VERSION === 0) {

--- a/tests/fixed/UselessConditions.php
+++ b/tests/fixed/UselessConditions.php
@@ -119,9 +119,7 @@ class UselessConditions
         return $this->isFalse() ? true : false;
     }
 
-    /**
-     * @param string[] $words
-     */
+    /** @param string[] $words */
     public function uselessTernaryCheck(array $words): bool
     {
         return count($words) < 1;

--- a/tests/fixed/class-references.php
+++ b/tests/fixed/class-references.php
@@ -8,9 +8,7 @@ class Foo
 
 class Bar extends Foo
 {
-    /**
-     * @return string[]
-     */
+    /** @return string[] */
     public function names(): iterable
     {
         yield self::class;

--- a/tests/fixed/doc-comment-spacing.php
+++ b/tests/fixed/doc-comment-spacing.php
@@ -71,4 +71,9 @@ class Test
     public function d(iterable $foo, iterable $bar): iterable
     {
     }
+
+    /** @param iterable<mixed> $singleAnnotation */
+    public function e(iterable $singleAnnotation): void
+    {
+    }
 }

--- a/tests/fixed/example-class.php
+++ b/tests/fixed/example-class.php
@@ -53,9 +53,7 @@ class Example implements IteratorAggregate
         return $this->foo;
     }
 
-    /**
-     * @return iterable
-     */
+    /** @return iterable */
     public function getIterator(): array
     {
         assert($this->bar !== null);
@@ -70,9 +68,7 @@ class Example implements IteratorAggregate
         return $this->baz;
     }
 
-    /**
-     * @throws InvalidArgumentException if this example cannot baz.
-     */
+    /** @throws InvalidArgumentException if this example cannot baz. */
     public function mangleBar(int $length): void
     {
         if (! $this->baz) {

--- a/tests/fixed/test-case.php
+++ b/tests/fixed/test-case.php
@@ -6,9 +6,7 @@ namespace Fancy;
 
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
-/**
- * @requires PHP 7.2
- */
+/** @requires PHP 7.2 */
 final class TestCase extends BaseTestCase
 {
     /**
@@ -19,9 +17,7 @@ final class TestCase extends BaseTestCase
     {
     }
 
-    /**
-     * @before
-     */
+    /** @before */
     public function createDependencies(): void
     {
     }

--- a/tests/input/ControlStructures.php
+++ b/tests/input/ControlStructures.php
@@ -13,9 +13,7 @@ class ControlStructures
 {
     private const VERSION = PHP_VERSION;
 
-    /**
-     * @return iterable<int>
-     */
+    /** @return iterable<int> */
     public function varAndIfNoSpaceBetween(): iterable
     {
         $var = 1;
@@ -24,9 +22,7 @@ class ControlStructures
         }
     }
 
-    /**
-     * @return iterable<int>
-     */
+    /** @return iterable<int> */
     public function ifAndYieldSpaceBetween(): iterable
     {
         if (self::VERSION === 0) {
@@ -35,9 +31,7 @@ class ControlStructures
         yield 1;
     }
 
-    /**
-     * @return iterable<int>
-     */
+    /** @return iterable<int> */
     public function ifAndYieldFromSpaceBetween(): iterable
     {
         if (self::VERSION === 0) {

--- a/tests/input/UselessConditions.php
+++ b/tests/input/UselessConditions.php
@@ -151,9 +151,7 @@ class UselessConditions
         return $this->isFalse() ? true : false;
     }
 
-    /**
-     * @param string[] $words
-     */
+    /** @param string[] $words */
     public function uselessTernaryCheck(array $words): bool
     {
         return count($words) >= 1 ? false : true;

--- a/tests/input/class-references.php
+++ b/tests/input/class-references.php
@@ -8,9 +8,7 @@ class Foo
 
 class Bar extends Foo
 {
-    /**
-     * @return string[]
-     */
+    /** @return string[] */
     public function names(): iterable
     {
         yield __CLASS__;

--- a/tests/input/doc-comment-spacing.php
+++ b/tests/input/doc-comment-spacing.php
@@ -67,4 +67,11 @@ class Test
     public function d(iterable $foo, iterable $bar): iterable
     {
     }
+
+    /**
+     * @param iterable<mixed> $singleAnnotation
+     */
+    public function e(iterable $singleAnnotation): void
+    {
+    }
 }

--- a/tests/input/test-case.php
+++ b/tests/input/test-case.php
@@ -21,9 +21,7 @@ final class TestCase extends BaseTestCase
     {
     }
 
-    /**
-     * @before
-     */
+    /** @before */
     public function createDependencies()
     {
     }

--- a/tests/php-compatibility.patch
+++ b/tests/php-compatibility.patch
@@ -3,11 +3,11 @@ index fd5432c..233e24d 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
 @@ -15,7 +15,7 @@ tests/input/ControlStructures.php                     28      0
- tests/input/doc-comment-spacing.php                   10      0
+ tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
  tests/input/EarlyReturn.php                           6       0
--tests/input/example-class.php                         36      0
-+tests/input/example-class.php                         39      0
+-tests/input/example-class.php                         38      0
++tests/input/example-class.php                         41      0
  tests/input/forbidden-comments.php                    14      0
  tests/input/forbidden-functions.php                   6       0
  tests/input/inline_type_hint_assertions.php           7       0
@@ -34,11 +34,11 @@ index fd5432c..233e24d 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 374 ERRORS AND 0 WARNINGS WERE FOUND IN 41 FILES
-+A TOTAL OF 383 ERRORS AND 0 WARNINGS WERE FOUND IN 41 FILES
+-A TOTAL OF 377 ERRORS AND 0 WARNINGS WERE FOUND IN 41 FILES
++A TOTAL OF 386 ERRORS AND 0 WARNINGS WERE FOUND IN 41 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 310 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 319 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 313 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 322 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  


### PR DESCRIPTION
This reduces vertical space in code. Same as it's already done for `@var` annotations as

```php
/**
 * @var mixed
 */
```

```php
/** @var mixed */
```

is now done for other annotations

```php
/**
 * @param mixed $param
 */
```

```php
/** @param mixed $param */
```