### PR TITLE
Increase versions only if necessary

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -8,4 +8,4 @@ update_configs:
       - "doctrine/coding-standard-approvers"
     default_labels:
       - "Dependencies"
-    version_requirement_updates: "increase_versions"
+    version_requirement_updates: "increase_versions_if_necessary"


### PR DESCRIPTION
Dependabot is creating many PRs which require new versions of packages
for no good reason.
This new strategy will bump version constraints only when necessary,
i.e. in order to get a major upgrade.
Another strategy would be to let it widen the range, but it does not
make much sense for a coding standard packages such as this one, since
users are unlikely to have a dependency on the dependencies of this
package. Note that we do have 2 dependencies that use pipes:
- one is on PHP, and it makes sense to keep it;
- one is on a package that is a composer plugin, and we might want to
drop it once Composer 1 usages is deemed low enough.

Closes #253 , closes #233