### PR TITLE
feat: add rules for trailing commas in function declarations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,14 @@ update-compatibility-patch-74:
 	@git apply tests/php74-compatibility.patch
 	@printf "Please open your editor and apply your changes\n"
 	@until [ "$${compatibility_resolved}" == "y" ]; do read -p "Have finished your changes (y|n)? " compatibility_resolved; done && compatibility_resolved=
-	@git diff -- tests/expected_report.txt tests/fixed > .tmp-patch && mv .tmp-patch tests/php74-compatibility.patch && git apply -R tests/php74-compatibility.patch
+	@git diff -- tests/expected_report.txt tests/fixed tests/input > .tmp-patch && mv .tmp-patch tests/php74-compatibility.patch && git apply -R tests/php74-compatibility.patch
 	@git commit -m 'Update compatibility patch' tests/php74-compatibility.patch
 
 update-compatibility-patch-80:
 	@git apply tests/php80-compatibility.patch
 	@printf "Please open your editor and apply your changes\n"
 	@until [ "$${compatibility_resolved}" == "y" ]; do read -p "Have finished your changes (y|n)? " compatibility_resolved; done && compatibility_resolved=
-	@git diff -- tests/expected_report.txt tests/fixed > .tmp-patch-80 && mv .tmp-patch-80 tests/php80-compatibility.patch && git apply -R tests/php80-compatibility.patch
+	@git diff -- tests/expected_report.txt tests/fixed tests/input > .tmp-patch-80 && mv .tmp-patch-80 tests/php80-compatibility.patch && git apply -R tests/php80-compatibility.patch
 	@git commit -m 'Update compatibility patch' tests/php80-compatibility.patch
 
 vendor: composer.json

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -284,6 +284,14 @@
             <property name="spacesCountAfterArrow" value="1"/>
         </properties>
     </rule>
+    <!-- Disallow trailing commas in single line function declarations -->
+    <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration">
+        <properties>
+            <property name="onlySingleLine" value="true" />
+        </properties>
+    </rule>
+    <!-- Require trailing commas in multiline function declarations -->
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
     <!-- Require closures not referencing $this be static -->
     <rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>
     <!-- Forbid unused variables passed to closures via `use` -->

--- a/tests/fixed/TrailingCommaOnFunctions.php
+++ b/tests/fixed/TrailingCommaOnFunctions.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine;
+
+class TrailingCommaOnFunctions
+{
+    public function a(int $arg): void
+    {
+    }
+
+    public function b(
+        int $arg
+    ): void {
+    }
+}

--- a/tests/input/TrailingCommaOnFunctions.php
+++ b/tests/input/TrailingCommaOnFunctions.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine;
+
+class TrailingCommaOnFunctions
+{
+    public function a(int $arg): void
+    {
+    }
+
+    public function b(
+        int $arg
+    ): void {
+    }
+}

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -97,6 +97,19 @@ index 1421913..d52353c 100644
 -    public ?string $nullableString = null;
 +    public string|null $nullableString = null;
  }
+diff --git a/tests/fixed/TrailingCommaOnFunctions.php b/tests/fixed/TrailingCommaOnFunctions.php
+index ed304c9..001650f 100644
+--- a/tests/fixed/TrailingCommaOnFunctions.php
++++ b/tests/fixed/TrailingCommaOnFunctions.php
+@@ -11,7 +11,7 @@ class TrailingCommaOnFunctions
+     }
+ 
+     public function b(
+-        int $arg
++        int $arg,
+     ): void {
+     }
+ }
 diff --git a/tests/fixed/UselessConditions.php b/tests/fixed/UselessConditions.php
 index 2151b17..71e0cfb 100644
 --- a/tests/fixed/UselessConditions.php
@@ -205,8 +218,105 @@ index 5bbb636..7ce8a3d 100644
  
 -$var = $object === null ? null : $object->property;
 +$var = $object?->property;
+diff --git a/tests/fixed/return_type_on_closures.php b/tests/fixed/return_type_on_closures.php
+index 134bade..80ad413 100644
+--- a/tests/fixed/return_type_on_closures.php
++++ b/tests/fixed/return_type_on_closures.php
+@@ -22,7 +22,7 @@ static function (
+     int $c,
+     int $d,
+     int $e,
+-    int $b
++    int $b,
+ ): void {
+ }
+ 
+@@ -31,7 +31,7 @@ static function (
+     int $c,
+     int $d,
+     int $e,
+-    int $b
++    int $b,
+ ): void {
+ }
+ 
+@@ -40,7 +40,7 @@ static function (
+     int $c,
+     int $d,
+     int $e,
+-    int $b
++    int $b,
+ ): void {
+ }
+ 
+@@ -49,7 +49,7 @@ static function (
+     int $c,
+     int $d,
+     int $e,
+-    int $b
++    int $b,
+ ): void {
+ }
+ 
+@@ -58,6 +58,6 @@ static function (
+     int $c,
+     int $d,
+     int $e,
+-    int $b
++    int $b,
+ ): void {
+ }
+diff --git a/tests/fixed/return_type_on_methods.php b/tests/fixed/return_type_on_methods.php
+index 8e2c6f7..0c897ae 100644
+--- a/tests/fixed/return_type_on_methods.php
++++ b/tests/fixed/return_type_on_methods.php
+@@ -31,7 +31,7 @@ class Test
+         int $c,
+         int $d,
+         int $e,
+-        int $b
++        int $b,
+     ): void {
+     }
+ 
+@@ -40,7 +40,7 @@ class Test
+         int $c,
+         int $d,
+         int $e,
+-        int $b
++        int $b,
+     ): void {
+     }
+ 
+@@ -49,7 +49,7 @@ class Test
+         int $c,
+         int $d,
+         int $e,
+-        int $b
++        int $b,
+     ): void {
+     }
+ 
+@@ -58,7 +58,7 @@ class Test
+         int $c,
+         int $d,
+         int $e,
+-        int $b
++        int $b,
+     ): void {
+     }
+ 
+@@ -67,7 +67,7 @@ class Test
+         int $c,
+         int $d,
+         int $e,
+-        int $b
++        int $b,
+     ): void {
+     }
+ }
 diff --git a/tests/fixed/type-hints.php b/tests/fixed/type-hints.php
-index 6033eca..5e26ed8 100644
+index 10e6f34..5e26ed8 100644
 --- a/tests/fixed/type-hints.php
 +++ b/tests/fixed/type-hints.php
 @@ -10,7 +10,7 @@ use Traversable;
@@ -226,3 +336,16 @@ index 6033eca..5e26ed8 100644
 -    private $x = 1;
 +    private int|string|null $x = 1;
  }
+diff --git a/tests/input/TrailingCommaOnFunctions.php b/tests/input/TrailingCommaOnFunctions.php
+index ed304c9..e383ee2 100644
+--- a/tests/input/TrailingCommaOnFunctions.php
++++ b/tests/input/TrailingCommaOnFunctions.php
+@@ -6,7 +6,7 @@ namespace Doctrine;
+ 
+ class TrailingCommaOnFunctions
+ {
+-    public function a(int $arg): void
++    public function a(int $arg,): void
+     {
+     }
+ 


### PR DESCRIPTION
Removes trailing commas on single line declarations

```diff
- function foo(int $x,): void
+ function foo(int $x): void
{
}
```
-------

Requires comma in multiline declarations
```diff
function foo(
    $bar,
    $baz,
)
```

so extending args produces nice diff (one line modified)
```diff
function foo(
    $bar,
    $baz,
+   $bam,
)
```