### PR TITLE
fix: use tmp-patch file name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,14 +28,14 @@ update-compatibility-patch-80:
 	@git apply tests/php80-compatibility.patch
 	@printf "Please open your editor and apply your changes\n"
 	@until [ "$${compatibility_resolved}" == "y" ]; do read -p "Have finished your changes (y|n)? " compatibility_resolved; done && compatibility_resolved=
-	@git diff -- tests/expected_report.txt tests/fixed > .tmp-patch-80 && mv .tmp-patch-80 tests/php80-compatibility.patch && git apply -R tests/php80-compatibility.patch
+	@git diff -- tests/expected_report.txt tests/fixed > .tmp-patch && mv .tmp-patch tests/php80-compatibility.patch && git apply -R tests/php80-compatibility.patch
 	@git commit -m 'Update compatibility patch' tests/php80-compatibility.patch
 
 update-compatibility-patch-81:
 	@git apply tests/php81-compatibility.patch
 	@printf "Please open your editor and apply your changes\n"
 	@until [ "$${compatibility_resolved}" == "y" ]; do read -p "Have finished your changes (y|n)? " compatibility_resolved; done && compatibility_resolved=
-	@git diff -- tests/expected_report.txt tests/fixed > .tmp-patch-81 && mv .tmp-patch-80 tests/php81-compatibility.patch && git apply -R tests/php81-compatibility.patch
+	@git diff -- tests/expected_report.txt tests/fixed > .tmp-patch && mv .tmp-patch tests/php81-compatibility.patch && git apply -R tests/php81-compatibility.patch
 	@git commit -m 'Update compatibility patch' tests/php81-compatibility.patch
 
 vendor: composer.json


### PR DESCRIPTION
We cannot run multiple update-compatibility-patch-* make targets at the same time so there's no need for having php version suffix in tmp-patch filename