### PR TITLE
ci: do not throw away exit codes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 /.gitattributes export-ignore
 /.github export-ignore
 /.gitignore export-ignore
+/bin/ export-ignore
 /docs/ export-ignore
 /phpcs.xml.dist export-ignore
 /tests/ export-ignore

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,12 @@
 .PHONY: test test-report test-fix update-compatibility-patch
 
-PHP_VERSION:=$(shell php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;")
-PATCH_FILE="tests/php$(PHP_VERSION)-compatibility.patch"
-
 test: test-report test-fix
 
 test-report: vendor
-	@if [ -f "$(PATCH_FILE)" ]; then git apply $(PATCH_FILE) ; fi
-	@vendor/bin/phpcs `find tests/input/* | sort` --report=summary --report-file=phpcs.log; diff -u tests/expected_report.txt phpcs.log; if [ $$? -ne 0 ] && [ -f "$(PATCH_FILE)" ]; then git apply -R $(PATCH_FILE) ; exit 1; fi
-	@if [ -f "$(PATCH_FILE)" ]; then git apply -R $(PATCH_FILE) ; fi
+	./bin/test-report
 
 test-fix: vendor
-	@if [ -f "$(PATCH_FILE)" ]; then git apply $(PATCH_FILE) ; fi
-	@cp -R tests/input/ tests/input2/
-	@vendor/bin/phpcbf tests/input2; diff -u tests/input2 tests/fixed; if [ $$? -ne 0 ]; then rm -rf tests/input2/; if [ -f "$(PATCH_FILE)" ]; then git apply -R $(PATCH_FILE) ; fi; exit 1; fi
-	@rm -rf tests/input2/;
-	@if [ -f "$(PATCH_FILE)" ]; then git apply -R $(PATCH_FILE) ; fi
+	./bin/test-fix
 
 update-compatibility-patch-74:
 	@git apply tests/php74-compatibility.patch

--- a/bin/cleanup
+++ b/bin/cleanup
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+. bin/patch-file
+
+rm -f phpcs.log
+rm -rf tests/input2/
+if [ -f "$PATCH_FILE" ]; then git apply -R "$PATCH_FILE" ; fi

--- a/bin/init
+++ b/bin/init
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+. bin/patch-file
+
+if [ -f "$PATCH_FILE" ]; then git apply "$PATCH_FILE" ; fi

--- a/bin/patch-file
+++ b/bin/patch-file
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+PHP_VERSION="$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;")"
+PATCH_FILE="tests/php$PHP_VERSION-compatibility.patch"
+
+export PATCH_FILE;

--- a/bin/test-fix
+++ b/bin/test-fix
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+bin/init
+trap 'bin/cleanup' EXIT
+
+set +e
+
+cp -R tests/input/ tests/input2/
+vendor/bin/phpcbf tests/input2
+diff -u tests/input2 tests/fixed

--- a/bin/test-report
+++ b/bin/test-report
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+bin/init
+trap 'bin/cleanup' EXIT
+
+set +e
+
+# shellcheck disable=SC2046
+vendor/bin/phpcs $(find tests/input/* | sort) --report=summary --report-file=phpcs.log
+diff -u tests/expected_report.txt phpcs.log

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -35,19 +35,20 @@ tests/input/semicolon_spacing.php                     3       0
 tests/input/single-line-array-spacing.php             5       0
 tests/input/spread-operator.php                       6       0
 tests/input/static-closures.php                       1       0
+tests/input/strings.php                               1       0
 tests/input/superfluous-naming.php                    11      0
 tests/input/test-case.php                             8       0
 tests/input/trailing_comma_on_array.php               1       0
 tests/input/traits-uses.php                           11      0
-tests/input/type-hints.php                            4       0
+tests/input/type-hints.php                            7       0
 tests/input/UnusedVariables.php                       1       0
 tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     20      0
 ----------------------------------------------------------------------
-A TOTAL OF 377 ERRORS AND 0 WARNINGS WERE FOUND IN 41 FILES
+A TOTAL OF 381 ERRORS AND 0 WARNINGS WERE FOUND IN 42 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 313 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 315 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/php74-compatibility.patch
+++ b/tests/php74-compatibility.patch
@@ -23,26 +23,26 @@ index c644926..7d122d2 100644
  tests/input/null_coalesce_operator.php                3       0
  tests/input/optimized-functions.php                   1       0
  tests/input/PropertyDeclaration.php                   6       0
-@@ -35,19 +35,20 @@ tests/input/semicolon_spacing.php                     3       0
+@@ -35,20 +35,20 @@ tests/input/semicolon_spacing.php                     3       0
  tests/input/single-line-array-spacing.php             5       0
  tests/input/spread-operator.php                       6       0
  tests/input/static-closures.php                       1       0
-+tests/input/strings.php                               1       0
+ tests/input/strings.php                               1       0
  tests/input/superfluous-naming.php                    11      0
  tests/input/test-case.php                             8       0
  tests/input/trailing_comma_on_array.php               1       0
  tests/input/traits-uses.php                           11      0
--tests/input/type-hints.php                            4       0
+-tests/input/type-hints.php                            7       0
 +tests/input/type-hints.php                            8       0
  tests/input/UnusedVariables.php                       1       0
  tests/input/use-ordering.php                          1       0
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 377 ERRORS AND 0 WARNINGS WERE FOUND IN 41 FILES
+-A TOTAL OF 381 ERRORS AND 0 WARNINGS WERE FOUND IN 42 FILES
 +A TOTAL OF 390 ERRORS AND 0 WARNINGS WERE FOUND IN 42 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 313 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 315 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 324 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -2,7 +2,7 @@ diff --git a/tests/expected_report.txt b/tests/expected_report.txt
 index 476a58b..54630dd 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
-@@ -14,40 +14,43 @@ tests/input/constants-var.php                         6       0
+@@ -14,41 +14,43 @@ tests/input/constants-var.php                         6       0
  tests/input/ControlStructures.php                     28      0
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
@@ -36,13 +36,13 @@ index 476a58b..54630dd 100644
  tests/input/single-line-array-spacing.php             5       0
  tests/input/spread-operator.php                       6       0
  tests/input/static-closures.php                       1       0
-+tests/input/strings.php                               1       0
+ tests/input/strings.php                               1       0
  tests/input/superfluous-naming.php                    11      0
  tests/input/test-case.php                             8       0
  tests/input/trailing_comma_on_array.php               1       0
 +tests/input/TrailingCommaOnFunctions.php              2       0
  tests/input/traits-uses.php                           11      0
--tests/input/type-hints.php                            4       0
+-tests/input/type-hints.php                            7       0
 +tests/input/type-hints.php                            9       0
  tests/input/UnusedVariables.php                       1       0
  tests/input/use-ordering.php                          1       0
@@ -50,10 +50,10 @@ index 476a58b..54630dd 100644
 -tests/input/UselessConditions.php                     20      0
 +tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 377 ERRORS AND 0 WARNINGS WERE FOUND IN 41 FILES
+-A TOTAL OF 381 ERRORS AND 0 WARNINGS WERE FOUND IN 42 FILES
 +A TOTAL OF 412 ERRORS AND 0 WARNINGS WERE FOUND IN 44 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 313 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 315 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 346 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  

--- a/tests/php81-compatibility.patch
+++ b/tests/php81-compatibility.patch
@@ -2,7 +2,7 @@ diff --git a/tests/expected_report.txt b/tests/expected_report.txt
 index 476a58b..54630dd 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
-@@ -14,40 +14,43 @@ tests/input/constants-var.php                         6       0
+@@ -14,41 +14,43 @@ tests/input/constants-var.php                         6       0
  tests/input/ControlStructures.php                     28      0
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
@@ -36,13 +36,13 @@ index 476a58b..54630dd 100644
  tests/input/single-line-array-spacing.php             5       0
  tests/input/spread-operator.php                       6       0
  tests/input/static-closures.php                       1       0
-+tests/input/strings.php                               1       0
+ tests/input/strings.php                               1       0
  tests/input/superfluous-naming.php                    11      0
  tests/input/test-case.php                             8       0
  tests/input/trailing_comma_on_array.php               1       0
 +tests/input/TrailingCommaOnFunctions.php              2       0
  tests/input/traits-uses.php                           11      0
--tests/input/type-hints.php                            4       0
+-tests/input/type-hints.php                            7       0
 +tests/input/type-hints.php                            9       0
  tests/input/UnusedVariables.php                       1       0
  tests/input/use-ordering.php                          1       0
@@ -50,10 +50,10 @@ index 476a58b..54630dd 100644
 -tests/input/UselessConditions.php                     20      0
 +tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 377 ERRORS AND 0 WARNINGS WERE FOUND IN 41 FILES
+-A TOTAL OF 381 ERRORS AND 0 WARNINGS WERE FOUND IN 42 FILES
 +A TOTAL OF 412 ERRORS AND 0 WARNINGS WERE FOUND IN 44 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 313 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 315 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 346 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  


### PR DESCRIPTION
I could have noticed this sooner but we were throwing away test failures on unpatched versions - exit code was being overridden.

I tried to fix it in Make first but then decided to go with bash because of its flexibility (e.g. can define variables and traps).