### PR TITLE
ci: disable fail-fast on tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,6 +88,7 @@ jobs:
     runs-on: "ubuntu-18.04"
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - "7.2"
@@ -125,6 +126,7 @@ jobs:
     runs-on: "ubuntu-18.04"
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - "7.2"


### PR DESCRIPTION
It's actually valuable to see all failed targets and their output since we use patches and php 8.1 is much different from php 7.2. So we don't want to terminate early.