### PR TITLE
chore: show sniff codes in all reports

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -13,6 +13,9 @@
     <!-- Show progress of the run -->
     <arg value="p"/>
 
+    <!--Show sniff codes in all reports -->
+    <arg value="s"/>
+
     <rule ref="Doctrine"/>
 
     <file>lib</file>


### PR DESCRIPTION
This makes debugging errors easier because we can see what sniffs are reported