### PR TITLE
feat: require non-capturing catch

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -287,6 +287,8 @@
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
     <!-- Require using Throwable instead of Exception -->
     <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"/>
+    <!-- Require non-capturing catch when the variable with exception is not used. -->
+    <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch" />
     <!-- Ensure Arrow Functions declaration format -->
     <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration">
         <properties>

--- a/tests/fixed/Exceptions.php
+++ b/tests/fixed/Exceptions.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Exceptions;

--- a/tests/input/Exceptions.php
+++ b/tests/input/Exceptions.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Exceptions;

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -1,8 +1,8 @@
 diff --git a/tests/expected_report.txt b/tests/expected_report.txt
-index 1d5a7d3..03460f2 100644
+index 53dada5..741d972 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
-@@ -14,23 +14,24 @@ tests/input/constants-var.php                         7       0
+@@ -14,23 +14,25 @@ tests/input/constants-var.php                         7       0
  tests/input/ControlStructures.php                     28      0
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
@@ -10,6 +10,7 @@ index 1d5a7d3..03460f2 100644
 -tests/input/example-class.php                         38      0
 +tests/input/EarlyReturn.php                           7       0
 +tests/input/example-class.php                         43      0
++tests/input/Exceptions.php                            1       0
  tests/input/forbidden-comments.php                    14      0
  tests/input/forbidden-functions.php                   6       0
  tests/input/inline_type_hint_assertions.php           7       0
@@ -35,7 +36,7 @@ index 1d5a7d3..03460f2 100644
  tests/input/semicolon_spacing.php                     3       0
  tests/input/single-line-array-spacing.php             5       0
  tests/input/spread-operator.php                       6       0
-@@ -39,16 +40,17 @@ tests/input/strings.php                               1       0
+@@ -39,16 +41,17 @@ tests/input/strings.php                               1       0
  tests/input/superfluous-naming.php                    11      0
  tests/input/test-case.php                             8       0
  tests/input/trailing_comma_on_array.php               1       0
@@ -50,13 +51,26 @@ index 1d5a7d3..03460f2 100644
 +tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
 -A TOTAL OF 382 ERRORS AND 0 WARNINGS WERE FOUND IN 42 FILES
-+A TOTAL OF 421 ERRORS AND 0 WARNINGS WERE FOUND IN 44 FILES
++A TOTAL OF 422 ERRORS AND 0 WARNINGS WERE FOUND IN 45 FILES
  ----------------------------------------------------------------------
 -PHPCBF CAN FIX 317 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 356 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 357 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  
+diff --git a/tests/fixed/ControlStructures.php b/tests/fixed/ControlStructures.php
+index a653086..f8f7f65 100644
+--- a/tests/fixed/ControlStructures.php
++++ b/tests/fixed/ControlStructures.php
+@@ -104,7 +104,7 @@ class ControlStructures
+ 
+         try {
+             echo 4;
+-        } catch (Throwable $throwable) {
++        } catch (Throwable) {
+         }
+ 
+         echo 5;
 diff --git a/tests/fixed/EarlyReturn.php b/tests/fixed/EarlyReturn.php
 index caf1dbb..fc734db 100644
 --- a/tests/fixed/EarlyReturn.php
@@ -70,6 +84,22 @@ index caf1dbb..fc734db 100644
      {
          foreach ($items as $item) {
              if (! $item->isItem()) {
+diff --git a/tests/fixed/Exceptions.php b/tests/fixed/Exceptions.php
+index 9b146c6..db7408b 100644
+--- a/tests/fixed/Exceptions.php
++++ b/tests/fixed/Exceptions.php
+@@ -3,3 +3,11 @@
+ declare(strict_types=1);
+ 
+ namespace Exceptions;
++
++use Exception;
++use Throwable;
++
++try {
++    throw new Exception();
++} catch (Throwable) {
++}
 diff --git a/tests/fixed/NamingCamelCase.php b/tests/fixed/NamingCamelCase.php
 index 57d9f2b..5493471 100644
 --- a/tests/fixed/NamingCamelCase.php
@@ -395,6 +425,35 @@ index 10e6f34..5e26ed8 100644
 -    private $x = 1;
 +    private int|string|null $x = 1;
  }
+diff --git a/tests/input/ControlStructures.php b/tests/input/ControlStructures.php
+index a0e0b2e..73944e3 100644
+--- a/tests/input/ControlStructures.php
++++ b/tests/input/ControlStructures.php
+@@ -93,7 +93,7 @@ class ControlStructures
+         }
+         try {
+             echo 4;
+-        } catch (Throwable $throwable) {
++        } catch (Throwable) {
+         }
+         echo 5;
+     }
+diff --git a/tests/input/Exceptions.php b/tests/input/Exceptions.php
+index 9b146c6..3aaa30f 100644
+--- a/tests/input/Exceptions.php
++++ b/tests/input/Exceptions.php
+@@ -3,3 +3,11 @@
+ declare(strict_types=1);
+ 
+ namespace Exceptions;
++
++use Exception;
++use Throwable;
++
++try {
++    throw new Exception();
++} catch (Throwable $throwable) {
++}
 diff --git a/tests/input/PropertyDeclaration.php b/tests/input/PropertyDeclaration.php
 index 0891e12..4eb8164 100644
 --- a/tests/input/PropertyDeclaration.php

--- a/tests/php81-compatibility.patch
+++ b/tests/php81-compatibility.patch
@@ -1,8 +1,8 @@
 diff --git a/tests/expected_report.txt b/tests/expected_report.txt
-index 1d5a7d3..e9394b1 100644
+index 53dada5..d53fd48 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
-@@ -14,23 +14,25 @@ tests/input/constants-var.php                         7       0
+@@ -14,23 +14,26 @@ tests/input/constants-var.php                         7       0
  tests/input/ControlStructures.php                     28      0
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
@@ -11,6 +11,7 @@ index 1d5a7d3..e9394b1 100644
 +tests/input/EarlyReturn.php                           7       0
 +tests/input/example-class.php                         43      0
 +tests/input/ExampleBackedEnum.php                     3       0
++tests/input/Exceptions.php                            1       0
  tests/input/forbidden-comments.php                    14      0
  tests/input/forbidden-functions.php                   6       0
  tests/input/inline_type_hint_assertions.php           7       0
@@ -36,7 +37,7 @@ index 1d5a7d3..e9394b1 100644
  tests/input/semicolon_spacing.php                     3       0
  tests/input/single-line-array-spacing.php             5       0
  tests/input/spread-operator.php                       6       0
-@@ -39,16 +41,17 @@ tests/input/strings.php                               1       0
+@@ -39,16 +42,17 @@ tests/input/strings.php                               1       0
  tests/input/superfluous-naming.php                    11      0
  tests/input/test-case.php                             8       0
  tests/input/trailing_comma_on_array.php               1       0
@@ -51,13 +52,26 @@ index 1d5a7d3..e9394b1 100644
 +tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
 -A TOTAL OF 382 ERRORS AND 0 WARNINGS WERE FOUND IN 42 FILES
-+A TOTAL OF 427 ERRORS AND 0 WARNINGS WERE FOUND IN 45 FILES
++A TOTAL OF 428 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
  ----------------------------------------------------------------------
 -PHPCBF CAN FIX 317 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 362 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 363 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  
+diff --git a/tests/fixed/ControlStructures.php b/tests/fixed/ControlStructures.php
+index a653086..f8f7f65 100644
+--- a/tests/fixed/ControlStructures.php
++++ b/tests/fixed/ControlStructures.php
+@@ -104,7 +104,7 @@ class ControlStructures
+ 
+         try {
+             echo 4;
+-        } catch (Throwable $throwable) {
++        } catch (Throwable) {
+         }
+ 
+         echo 5;
 diff --git a/tests/fixed/EarlyReturn.php b/tests/fixed/EarlyReturn.php
 index caf1dbb..fc734db 100644
 --- a/tests/fixed/EarlyReturn.php
@@ -82,6 +96,22 @@ index fe54eb9..cc38c54 100644
 +
 +enum ExampleBackedEnum: int
 +{
++}
+diff --git a/tests/fixed/Exceptions.php b/tests/fixed/Exceptions.php
+index 9b146c6..db7408b 100644
+--- a/tests/fixed/Exceptions.php
++++ b/tests/fixed/Exceptions.php
+@@ -3,3 +3,11 @@
+ declare(strict_types=1);
+ 
+ namespace Exceptions;
++
++use Exception;
++use Throwable;
++
++try {
++    throw new Exception();
++} catch (Throwable) {
 +}
 diff --git a/tests/fixed/NamingCamelCase.php b/tests/fixed/NamingCamelCase.php
 index 57d9f2b..5493471 100644
@@ -408,6 +438,19 @@ index 10e6f34..5e26ed8 100644
 -    private $x = 1;
 +    private int|string|null $x = 1;
  }
+diff --git a/tests/input/ControlStructures.php b/tests/input/ControlStructures.php
+index a0e0b2e..73944e3 100644
+--- a/tests/input/ControlStructures.php
++++ b/tests/input/ControlStructures.php
+@@ -93,7 +93,7 @@ class ControlStructures
+         }
+         try {
+             echo 4;
+-        } catch (Throwable $throwable) {
++        } catch (Throwable) {
+         }
+         echo 5;
+     }
 diff --git a/tests/input/ExampleBackedEnum.php b/tests/input/ExampleBackedEnum.php
 index fe54eb9..0c47286 100644
 --- a/tests/input/ExampleBackedEnum.php
@@ -419,6 +462,22 @@ index fe54eb9..0c47286 100644
 +
 +enum ExampleBackedEnum :   int
 +{
++}
+diff --git a/tests/input/Exceptions.php b/tests/input/Exceptions.php
+index 9b146c6..3aaa30f 100644
+--- a/tests/input/Exceptions.php
++++ b/tests/input/Exceptions.php
+@@ -3,3 +3,11 @@
+ declare(strict_types=1);
+ 
+ namespace Exceptions;
++
++use Exception;
++use Throwable;
++
++try {
++    throw new Exception();
++} catch (Throwable $throwable) {
 +}
 diff --git a/tests/input/PropertyDeclaration.php b/tests/input/PropertyDeclaration.php
 index 0891e12..acdc445 100644


### PR DESCRIPTION
to avoid unused redundant variables in catch blocks