### PR TITLE
feat: remove SlevomatCodingStandard.Operators.DisallowEqualOperators

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -369,8 +369,6 @@
     </rule>
     <!-- Forbid useless alias for classes, constants and functions -->
     <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
-    <!-- Forbid weak comparisons -->
-    <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
     <!-- Forbid spacing before the negative operator `-` -->
     <rule ref="SlevomatCodingStandard.Operators.NegationOperatorSpacing"/>
     <!-- Require the usage of assignment operators, eg `+=`, `.=` when possible -->


### PR DESCRIPTION
We can use phpstan for that which handles it better

https://phpstan.org/r/977a0017-a744-4a9c-8bc8-6e580ff5ec1b (strict+bleeding edge checked)