### PR TITLE
refactor: just rerun patch targets

### DIFF
--- a/tests/php72-compatibility.patch
+++ b/tests/php72-compatibility.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/expected_report.txt b/tests/expected_report.txt
-index 5110131..53dada5 100644
+index 151bce4..0afca8c 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
 @@ -14,26 +14,23 @@ tests/input/constants-var.php                         7       0
@@ -63,7 +63,7 @@ diff --git a/tests/fixed/ControlStructures.php b/tests/fixed/ControlStructures.p
 index f8f7f65..a653086 100644
 --- a/tests/fixed/ControlStructures.php
 +++ b/tests/fixed/ControlStructures.php
-@@ -104,7 +104,7 @@ public function spaceBelowBlocks(): void
+@@ -104,7 +104,7 @@ class ControlStructures
  
          try {
              echo 4;
@@ -76,7 +76,7 @@ diff --git a/tests/fixed/EarlyReturn.php b/tests/fixed/EarlyReturn.php
 index fc734db..caf1dbb 100644
 --- a/tests/fixed/EarlyReturn.php
 +++ b/tests/fixed/EarlyReturn.php
-@@ -11,7 +11,7 @@ public function bar(): bool
+@@ -11,7 +11,7 @@ class EarlyReturn
          return $bar === 'bar';
      }
  
@@ -117,7 +117,7 @@ diff --git a/tests/fixed/NamingCamelCase.php b/tests/fixed/NamingCamelCase.php
 index 5493471..57d9f2b 100644
 --- a/tests/fixed/NamingCamelCase.php
 +++ b/tests/fixed/NamingCamelCase.php
-@@ -6,11 +6,14 @@
+@@ -6,11 +6,14 @@ namespace Example;
  
  class NamingCamelCase
  {
@@ -155,7 +155,7 @@ diff --git a/tests/fixed/TrailingCommaOnFunctions.php b/tests/fixed/TrailingComm
 index 4248238..f3ffa91 100644
 --- a/tests/fixed/TrailingCommaOnFunctions.php
 +++ b/tests/fixed/TrailingCommaOnFunctions.php
-@@ -15,7 +15,7 @@ public function a(int $arg): void
+@@ -15,7 +15,7 @@ class TrailingCommaOnFunctions
      }
  
      public function b(
@@ -164,7 +164,7 @@ index 4248238..f3ffa91 100644
      ): void {
      }
  
-@@ -28,7 +28,7 @@ public function uses(): void
+@@ -28,7 +28,7 @@ class TrailingCommaOnFunctions
          };
  
          $multiLine = static function (int $arg) use (
@@ -173,7 +173,7 @@ index 4248238..f3ffa91 100644
          ): void {
              var_dump($var);
          };
-@@ -37,9 +37,8 @@ public function uses(): void
+@@ -37,9 +37,8 @@ class TrailingCommaOnFunctions
  
  $class = new TrailingCommaOnFunctions();
  
@@ -188,7 +188,7 @@ diff --git a/tests/fixed/UselessConditions.php b/tests/fixed/UselessConditions.p
 index 71e0cfb..2151b17 100644
 --- a/tests/fixed/UselessConditions.php
 +++ b/tests/fixed/UselessConditions.php
-@@ -95,7 +95,7 @@ public function necessaryIfConditionWithMethodCall(): bool
+@@ -95,7 +95,7 @@ class UselessConditions
          return false;
      }
  
@@ -201,7 +201,7 @@ diff --git a/tests/fixed/arrow-functions-format.php b/tests/fixed/arrow-function
 index 4da39b8..a45074f 100644
 --- a/tests/fixed/arrow-functions-format.php
 +++ b/tests/fixed/arrow-functions-format.php
-@@ -18,10 +18,10 @@
+@@ -18,10 +18,10 @@ $returningObject = static fn () => new stdClass();
  
  $multiLineArrowFunctions = Collection::from([1, 2])
      ->map(
@@ -215,10 +215,10 @@ index 4da39b8..a45074f 100644
  
  $thisIsNotAnArrowFunction = [$this->fn => 'value'];
 diff --git a/tests/fixed/example-class.php b/tests/fixed/example-class.php
-index 7d27825..998e51d 100644
+index 4988dab..2df56a0 100644
 --- a/tests/fixed/example-class.php
 +++ b/tests/fixed/example-class.php
-@@ -29,19 +29,32 @@ class Example extends ParentClass implements IteratorAggregate
+@@ -29,10 +29,23 @@ class Example extends ParentClass implements IteratorAggregate
  {
      private const VERSION = PHP_VERSION - (PHP_MINOR_VERSION * 100) - PHP_PATCH_VERSION;
  
@@ -242,10 +242,9 @@ index 7d27825..998e51d 100644
 +        $this->bar    = $bar;
 +        $this->baz    = $baz;
          $this->baxBax = $baxBax;
-
-         parent::__construct();
-     }
  
+         parent::__construct();
+@@ -41,7 +54,7 @@ class Example extends ParentClass implements IteratorAggregate
      /**
       * Description
       */
@@ -258,7 +257,7 @@ diff --git a/tests/fixed/namespaces-spacing.php b/tests/fixed/namespaces-spacing
 index 36cbae2..d42bbfe 100644
 --- a/tests/fixed/namespaces-spacing.php
 +++ b/tests/fixed/namespaces-spacing.php
-@@ -16,5 +16,5 @@
+@@ -16,5 +16,5 @@ use const DATE_RFC3339;
  strrev(
      (new DateTimeImmutable('@' . time(), new DateTimeZone('UTC')))
          ->sub(new DateInterval('P1D'))
@@ -269,7 +268,7 @@ diff --git a/tests/fixed/new_with_parentheses.php b/tests/fixed/new_with_parenth
 index 47a06ec..6e81bbe 100644
 --- a/tests/fixed/new_with_parentheses.php
 +++ b/tests/fixed/new_with_parentheses.php
-@@ -24,5 +24,5 @@
+@@ -24,5 +24,5 @@ $y = [new stdClass()];
  
  $z = new stdClass() ? new stdClass() : new stdClass();
  
@@ -303,7 +302,7 @@ diff --git a/tests/fixed/null_coalesce_operator.php b/tests/fixed/null_coalesce_
 index 51c361c..8846dd1 100644
 --- a/tests/fixed/null_coalesce_operator.php
 +++ b/tests/fixed/null_coalesce_operator.php
-@@ -4,7 +4,7 @@
+@@ -4,7 +4,7 @@ declare(strict_types=1);
  
  $foo = $_GET['foo'] ?? 'foo';
  
@@ -374,7 +373,7 @@ diff --git a/tests/fixed/return_type_on_methods.php b/tests/fixed/return_type_on
 index 0c897ae..8e2c6f7 100644
 --- a/tests/fixed/return_type_on_methods.php
 +++ b/tests/fixed/return_type_on_methods.php
-@@ -31,7 +31,7 @@ public function f(
+@@ -31,7 +31,7 @@ class Test
          int $c,
          int $d,
          int $e,
@@ -383,7 +382,7 @@ index 0c897ae..8e2c6f7 100644
      ): void {
      }
  
-@@ -40,7 +40,7 @@ public function g(
+@@ -40,7 +40,7 @@ class Test
          int $c,
          int $d,
          int $e,
@@ -392,7 +391,7 @@ index 0c897ae..8e2c6f7 100644
      ): void {
      }
  
-@@ -49,7 +49,7 @@ public function h(
+@@ -49,7 +49,7 @@ class Test
          int $c,
          int $d,
          int $e,
@@ -401,7 +400,7 @@ index 0c897ae..8e2c6f7 100644
      ): void {
      }
  
-@@ -58,7 +58,7 @@ public function i(
+@@ -58,7 +58,7 @@ class Test
          int $c,
          int $d,
          int $e,
@@ -410,7 +409,7 @@ index 0c897ae..8e2c6f7 100644
      ): void {
      }
  
-@@ -67,7 +67,7 @@ public function j(
+@@ -67,7 +67,7 @@ class Test
          int $c,
          int $d,
          int $e,
@@ -423,7 +422,7 @@ diff --git a/tests/fixed/type-hints.php b/tests/fixed/type-hints.php
 index 5e26ed8..10e6f34 100644
 --- a/tests/fixed/type-hints.php
 +++ b/tests/fixed/type-hints.php
-@@ -10,7 +10,7 @@
+@@ -10,7 +10,7 @@ use Traversable;
  class TraversableTypeHints
  {
      /** @var Traversable */
@@ -432,7 +431,7 @@ index 5e26ed8..10e6f34 100644
  
      /**
       * @param Iterator $iterator
-@@ -25,5 +25,6 @@ public function get(Iterator $iterator): Traversable
+@@ -25,5 +25,6 @@ class TraversableTypeHints
  
  class UnionTypeHints
  {
@@ -444,7 +443,7 @@ diff --git a/tests/input/ControlStructures.php b/tests/input/ControlStructures.p
 index 73944e3..a0e0b2e 100644
 --- a/tests/input/ControlStructures.php
 +++ b/tests/input/ControlStructures.php
-@@ -93,7 +93,7 @@ public function spaceBelowBlocks(): void
+@@ -93,7 +93,7 @@ class ControlStructures
          }
          try {
              echo 4;
@@ -499,7 +498,7 @@ diff --git a/tests/input/TrailingCommaOnFunctions.php b/tests/input/TrailingComm
 index fc5480e..f3ffa91 100644
 --- a/tests/input/TrailingCommaOnFunctions.php
 +++ b/tests/input/TrailingCommaOnFunctions.php
-@@ -10,7 +10,7 @@
+@@ -10,7 +10,7 @@ use function var_dump;
  
  class TrailingCommaOnFunctions
  {
@@ -508,7 +507,7 @@ index fc5480e..f3ffa91 100644
      {
      }
  
-@@ -23,7 +23,7 @@ public function uses(): void
+@@ -23,7 +23,7 @@ class TrailingCommaOnFunctions
      {
          $var = null;
  
@@ -517,7 +516,7 @@ index fc5480e..f3ffa91 100644
              var_dump($var);
          };
  
-@@ -37,8 +37,7 @@ public function uses(): void
+@@ -37,8 +37,7 @@ class TrailingCommaOnFunctions
  
  $class = new TrailingCommaOnFunctions();
  
@@ -531,7 +530,7 @@ diff --git a/tests/input/arrow-functions-format.php b/tests/input/arrow-function
 index d3903ff..8a358e8 100644
 --- a/tests/input/arrow-functions-format.php
 +++ b/tests/input/arrow-functions-format.php
-@@ -18,10 +18,10 @@
+@@ -18,10 +18,10 @@ $returningObject = static fn () => new stdClass();
  
  $multiLineArrowFunctions = Collection::from([1, 2])
      ->map(
@@ -548,7 +547,7 @@ diff --git a/tests/input/namespaces-spacing.php b/tests/input/namespaces-spacing
 index e7be018..e1ab639 100644
 --- a/tests/input/namespaces-spacing.php
 +++ b/tests/input/namespaces-spacing.php
-@@ -11,5 +11,5 @@
+@@ -11,5 +11,5 @@ use const DATE_RFC3339;
  strrev(
      (new DateTimeImmutable('@' . time(), new DateTimeZone('UTC')))
          ->sub(new DateInterval('P1D'))

--- a/tests/php73-compatibility.patch
+++ b/tests/php73-compatibility.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/expected_report.txt b/tests/expected_report.txt
-index 5110131..5616fdf 100644
+index 151bce4..94718eb 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
 @@ -14,26 +14,23 @@ tests/input/constants-var.php                         7       0
@@ -64,7 +64,7 @@ diff --git a/tests/fixed/ControlStructures.php b/tests/fixed/ControlStructures.p
 index f8f7f65..a653086 100644
 --- a/tests/fixed/ControlStructures.php
 +++ b/tests/fixed/ControlStructures.php
-@@ -104,7 +104,7 @@ public function spaceBelowBlocks(): void
+@@ -104,7 +104,7 @@ class ControlStructures
  
          try {
              echo 4;
@@ -77,7 +77,7 @@ diff --git a/tests/fixed/EarlyReturn.php b/tests/fixed/EarlyReturn.php
 index fc734db..caf1dbb 100644
 --- a/tests/fixed/EarlyReturn.php
 +++ b/tests/fixed/EarlyReturn.php
-@@ -11,7 +11,7 @@ public function bar(): bool
+@@ -11,7 +11,7 @@ class EarlyReturn
          return $bar === 'bar';
      }
  
@@ -118,7 +118,7 @@ diff --git a/tests/fixed/NamingCamelCase.php b/tests/fixed/NamingCamelCase.php
 index 5493471..57d9f2b 100644
 --- a/tests/fixed/NamingCamelCase.php
 +++ b/tests/fixed/NamingCamelCase.php
-@@ -6,11 +6,14 @@
+@@ -6,11 +6,14 @@ namespace Example;
  
  class NamingCamelCase
  {
@@ -156,7 +156,7 @@ diff --git a/tests/fixed/TrailingCommaOnFunctions.php b/tests/fixed/TrailingComm
 index 4248238..67173b3 100644
 --- a/tests/fixed/TrailingCommaOnFunctions.php
 +++ b/tests/fixed/TrailingCommaOnFunctions.php
-@@ -15,7 +15,7 @@ public function a(int $arg): void
+@@ -15,7 +15,7 @@ class TrailingCommaOnFunctions
      }
  
      public function b(
@@ -165,7 +165,7 @@ index 4248238..67173b3 100644
      ): void {
      }
  
-@@ -28,7 +28,7 @@ public function uses(): void
+@@ -28,7 +28,7 @@ class TrailingCommaOnFunctions
          };
  
          $multiLine = static function (int $arg) use (
@@ -178,7 +178,7 @@ diff --git a/tests/fixed/UselessConditions.php b/tests/fixed/UselessConditions.p
 index 71e0cfb..2151b17 100644
 --- a/tests/fixed/UselessConditions.php
 +++ b/tests/fixed/UselessConditions.php
-@@ -95,7 +95,7 @@ public function necessaryIfConditionWithMethodCall(): bool
+@@ -95,7 +95,7 @@ class UselessConditions
          return false;
      }
  
@@ -188,10 +188,10 @@ index 71e0cfb..2151b17 100644
          if (! $this->isAdmin) {
              return null;
 diff --git a/tests/fixed/example-class.php b/tests/fixed/example-class.php
-index 7d27825..998e51d 100644
+index 4988dab..2df56a0 100644
 --- a/tests/fixed/example-class.php
 +++ b/tests/fixed/example-class.php
-@@ -29,19 +29,32 @@ class Example extends ParentClass implements IteratorAggregate
+@@ -29,10 +29,23 @@ class Example extends ParentClass implements IteratorAggregate
  {
      private const VERSION = PHP_VERSION - (PHP_MINOR_VERSION * 100) - PHP_PATCH_VERSION;
  
@@ -215,10 +215,9 @@ index 7d27825..998e51d 100644
 +        $this->bar    = $bar;
 +        $this->baz    = $baz;
          $this->baxBax = $baxBax;
-
-         parent::__construct();
-     }
  
+         parent::__construct();
+@@ -41,7 +54,7 @@ class Example extends ParentClass implements IteratorAggregate
      /**
       * Description
       */
@@ -231,7 +230,7 @@ diff --git a/tests/fixed/new_with_parentheses.php b/tests/fixed/new_with_parenth
 index 47a06ec..6e81bbe 100644
 --- a/tests/fixed/new_with_parentheses.php
 +++ b/tests/fixed/new_with_parentheses.php
-@@ -24,5 +24,5 @@
+@@ -24,5 +24,5 @@ $y = [new stdClass()];
  
  $z = new stdClass() ? new stdClass() : new stdClass();
  
@@ -265,7 +264,7 @@ diff --git a/tests/fixed/null_coalesce_operator.php b/tests/fixed/null_coalesce_
 index 51c361c..8846dd1 100644
 --- a/tests/fixed/null_coalesce_operator.php
 +++ b/tests/fixed/null_coalesce_operator.php
-@@ -4,7 +4,7 @@
+@@ -4,7 +4,7 @@ declare(strict_types=1);
  
  $foo = $_GET['foo'] ?? 'foo';
  
@@ -336,7 +335,7 @@ diff --git a/tests/fixed/return_type_on_methods.php b/tests/fixed/return_type_on
 index 0c897ae..8e2c6f7 100644
 --- a/tests/fixed/return_type_on_methods.php
 +++ b/tests/fixed/return_type_on_methods.php
-@@ -31,7 +31,7 @@ public function f(
+@@ -31,7 +31,7 @@ class Test
          int $c,
          int $d,
          int $e,
@@ -345,7 +344,7 @@ index 0c897ae..8e2c6f7 100644
      ): void {
      }
  
-@@ -40,7 +40,7 @@ public function g(
+@@ -40,7 +40,7 @@ class Test
          int $c,
          int $d,
          int $e,
@@ -354,7 +353,7 @@ index 0c897ae..8e2c6f7 100644
      ): void {
      }
  
-@@ -49,7 +49,7 @@ public function h(
+@@ -49,7 +49,7 @@ class Test
          int $c,
          int $d,
          int $e,
@@ -363,7 +362,7 @@ index 0c897ae..8e2c6f7 100644
      ): void {
      }
  
-@@ -58,7 +58,7 @@ public function i(
+@@ -58,7 +58,7 @@ class Test
          int $c,
          int $d,
          int $e,
@@ -372,7 +371,7 @@ index 0c897ae..8e2c6f7 100644
      ): void {
      }
  
-@@ -67,7 +67,7 @@ public function j(
+@@ -67,7 +67,7 @@ class Test
          int $c,
          int $d,
          int $e,
@@ -385,7 +384,7 @@ diff --git a/tests/fixed/type-hints.php b/tests/fixed/type-hints.php
 index 5e26ed8..10e6f34 100644
 --- a/tests/fixed/type-hints.php
 +++ b/tests/fixed/type-hints.php
-@@ -10,7 +10,7 @@
+@@ -10,7 +10,7 @@ use Traversable;
  class TraversableTypeHints
  {
      /** @var Traversable */
@@ -394,7 +393,7 @@ index 5e26ed8..10e6f34 100644
  
      /**
       * @param Iterator $iterator
-@@ -25,5 +25,6 @@ public function get(Iterator $iterator): Traversable
+@@ -25,5 +25,6 @@ class TraversableTypeHints
  
  class UnionTypeHints
  {
@@ -406,7 +405,7 @@ diff --git a/tests/input/ControlStructures.php b/tests/input/ControlStructures.p
 index 73944e3..a0e0b2e 100644
 --- a/tests/input/ControlStructures.php
 +++ b/tests/input/ControlStructures.php
-@@ -93,7 +93,7 @@ public function spaceBelowBlocks(): void
+@@ -93,7 +93,7 @@ class ControlStructures
          }
          try {
              echo 4;
@@ -461,7 +460,7 @@ diff --git a/tests/input/TrailingCommaOnFunctions.php b/tests/input/TrailingComm
 index fc5480e..8adcedf 100644
 --- a/tests/input/TrailingCommaOnFunctions.php
 +++ b/tests/input/TrailingCommaOnFunctions.php
-@@ -10,7 +10,7 @@
+@@ -10,7 +10,7 @@ use function var_dump;
  
  class TrailingCommaOnFunctions
  {
@@ -470,7 +469,7 @@ index fc5480e..8adcedf 100644
      {
      }
  
-@@ -23,7 +23,7 @@ public function uses(): void
+@@ -23,7 +23,7 @@ class TrailingCommaOnFunctions
      {
          $var = null;
  

--- a/tests/php74-compatibility.patch
+++ b/tests/php74-compatibility.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/expected_report.txt b/tests/expected_report.txt
-index 5110131..dc2cf18 100644
+index 151bce4..08a098f 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
 @@ -14,26 +14,23 @@ tests/input/constants-var.php                         7       0
@@ -62,7 +62,7 @@ diff --git a/tests/fixed/ControlStructures.php b/tests/fixed/ControlStructures.p
 index f8f7f65..a653086 100644
 --- a/tests/fixed/ControlStructures.php
 +++ b/tests/fixed/ControlStructures.php
-@@ -104,7 +104,7 @@ public function spaceBelowBlocks(): void
+@@ -104,7 +104,7 @@ class ControlStructures
  
          try {
              echo 4;
@@ -75,7 +75,7 @@ diff --git a/tests/fixed/EarlyReturn.php b/tests/fixed/EarlyReturn.php
 index fc734db..caf1dbb 100644
 --- a/tests/fixed/EarlyReturn.php
 +++ b/tests/fixed/EarlyReturn.php
-@@ -11,7 +11,7 @@ public function bar(): bool
+@@ -11,7 +11,7 @@ class EarlyReturn
          return $bar === 'bar';
      }
  
@@ -116,7 +116,7 @@ diff --git a/tests/fixed/NamingCamelCase.php b/tests/fixed/NamingCamelCase.php
 index 5493471..57d9f2b 100644
 --- a/tests/fixed/NamingCamelCase.php
 +++ b/tests/fixed/NamingCamelCase.php
-@@ -6,11 +6,14 @@
+@@ -6,11 +6,14 @@ namespace Example;
  
  class NamingCamelCase
  {
@@ -154,7 +154,7 @@ diff --git a/tests/fixed/TrailingCommaOnFunctions.php b/tests/fixed/TrailingComm
 index 4248238..67173b3 100644
 --- a/tests/fixed/TrailingCommaOnFunctions.php
 +++ b/tests/fixed/TrailingCommaOnFunctions.php
-@@ -15,7 +15,7 @@ public function a(int $arg): void
+@@ -15,7 +15,7 @@ class TrailingCommaOnFunctions
      }
  
      public function b(
@@ -163,7 +163,7 @@ index 4248238..67173b3 100644
      ): void {
      }
  
-@@ -28,7 +28,7 @@ public function uses(): void
+@@ -28,7 +28,7 @@ class TrailingCommaOnFunctions
          };
  
          $multiLine = static function (int $arg) use (
@@ -176,7 +176,7 @@ diff --git a/tests/fixed/UselessConditions.php b/tests/fixed/UselessConditions.p
 index 71e0cfb..2151b17 100644
 --- a/tests/fixed/UselessConditions.php
 +++ b/tests/fixed/UselessConditions.php
-@@ -95,7 +95,7 @@ public function necessaryIfConditionWithMethodCall(): bool
+@@ -95,7 +95,7 @@ class UselessConditions
          return false;
      }
  
@@ -186,10 +186,10 @@ index 71e0cfb..2151b17 100644
          if (! $this->isAdmin) {
              return null;
 diff --git a/tests/fixed/example-class.php b/tests/fixed/example-class.php
-index 7d27825..7866379 100644
+index 4988dab..c31e53f 100644
 --- a/tests/fixed/example-class.php
 +++ b/tests/fixed/example-class.php
-@@ -29,19 +29,30 @@ class Example extends ParentClass implements IteratorAggregate
+@@ -29,10 +29,21 @@ class Example extends ParentClass implements IteratorAggregate
  {
      private const VERSION = PHP_VERSION - (PHP_MINOR_VERSION * 100) - PHP_PATCH_VERSION;
  
@@ -211,10 +211,9 @@ index 7d27825..7866379 100644
 +        $this->bar    = $bar;
 +        $this->baz    = $baz;
          $this->baxBax = $baxBax;
-
-         parent::__construct();
-     }
  
+         parent::__construct();
+@@ -41,7 +52,7 @@ class Example extends ParentClass implements IteratorAggregate
      /**
       * Description
       */
@@ -285,7 +284,7 @@ diff --git a/tests/fixed/return_type_on_methods.php b/tests/fixed/return_type_on
 index 0c897ae..8e2c6f7 100644
 --- a/tests/fixed/return_type_on_methods.php
 +++ b/tests/fixed/return_type_on_methods.php
-@@ -31,7 +31,7 @@ public function f(
+@@ -31,7 +31,7 @@ class Test
          int $c,
          int $d,
          int $e,
@@ -294,7 +293,7 @@ index 0c897ae..8e2c6f7 100644
      ): void {
      }
  
-@@ -40,7 +40,7 @@ public function g(
+@@ -40,7 +40,7 @@ class Test
          int $c,
          int $d,
          int $e,
@@ -303,7 +302,7 @@ index 0c897ae..8e2c6f7 100644
      ): void {
      }
  
-@@ -49,7 +49,7 @@ public function h(
+@@ -49,7 +49,7 @@ class Test
          int $c,
          int $d,
          int $e,
@@ -312,7 +311,7 @@ index 0c897ae..8e2c6f7 100644
      ): void {
      }
  
-@@ -58,7 +58,7 @@ public function i(
+@@ -58,7 +58,7 @@ class Test
          int $c,
          int $d,
          int $e,
@@ -321,7 +320,7 @@ index 0c897ae..8e2c6f7 100644
      ): void {
      }
  
-@@ -67,7 +67,7 @@ public function j(
+@@ -67,7 +67,7 @@ class Test
          int $c,
          int $d,
          int $e,
@@ -334,7 +333,7 @@ diff --git a/tests/fixed/type-hints.php b/tests/fixed/type-hints.php
 index 5e26ed8..bfa6d4f 100644
 --- a/tests/fixed/type-hints.php
 +++ b/tests/fixed/type-hints.php
-@@ -25,5 +25,6 @@ public function get(Iterator $iterator): Traversable
+@@ -25,5 +25,6 @@ class TraversableTypeHints
  
  class UnionTypeHints
  {
@@ -346,7 +345,7 @@ diff --git a/tests/input/ControlStructures.php b/tests/input/ControlStructures.p
 index 73944e3..a0e0b2e 100644
 --- a/tests/input/ControlStructures.php
 +++ b/tests/input/ControlStructures.php
-@@ -93,7 +93,7 @@ public function spaceBelowBlocks(): void
+@@ -93,7 +93,7 @@ class ControlStructures
          }
          try {
              echo 4;
@@ -401,7 +400,7 @@ diff --git a/tests/input/TrailingCommaOnFunctions.php b/tests/input/TrailingComm
 index fc5480e..8adcedf 100644
 --- a/tests/input/TrailingCommaOnFunctions.php
 +++ b/tests/input/TrailingCommaOnFunctions.php
-@@ -10,7 +10,7 @@
+@@ -10,7 +10,7 @@ use function var_dump;
  
  class TrailingCommaOnFunctions
  {
@@ -410,7 +409,7 @@ index fc5480e..8adcedf 100644
      {
      }
  
-@@ -23,7 +23,7 @@ public function uses(): void
+@@ -23,7 +23,7 @@ class TrailingCommaOnFunctions
      {
          $var = null;
  

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/expected_report.txt b/tests/expected_report.txt
-index 5110131..f0a3fc9 100644
+index 151bce4..873691d 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
 @@ -16,7 +16,6 @@ tests/input/doc-comment-spacing.php                   11      0


### PR DESCRIPTION
_Addresses https://github.com/doctrine/coding-standard/pull/282#pullrequestreview-1114528770_

Running patch targets while not making any changes produced resulting diffs anyway.

So after this PR the current state will be that running patch targets without making any changes does nothing actually.  
Which is desired since we do not want irrelevant changes in PRs that modify a patch.

TLDR this just recreates patches.