### PR TITLE
feat(explicit assertions): enable advanced string types and integer ranges

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
-        "slevomat/coding-standard": "^8.2",
+        "slevomat/coding-standard": "^8.5.1",
         "squizlabs/php_codesniffer": "^3.7"
     },
     "config": {

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -411,7 +411,12 @@
     <!-- Forbid useless semicolon `;` -->
     <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
     <!-- Require /* @var type $foo */ and similar simple inline annotations to be replaced by assert() -->
-    <rule ref="SlevomatCodingStandard.PHP.RequireExplicitAssertion"/>
+    <rule ref="SlevomatCodingStandard.PHP.RequireExplicitAssertion">
+        <properties>
+            <property name="enableAdvancedStringTypes" value="true"/>
+            <property name="enableIntegerRanges" value="true"/>
+        </properties>
+    </rule>
     <!-- Require use of short versions of scalar types (i.e. int instead of integer) -->
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
     <!-- Require the `null` type hint to be in the last position of annotations -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -20,7 +20,7 @@ tests/input/ExampleBackedEnum.php                     3       0
 tests/input/Exceptions.php                            1       0
 tests/input/forbidden-comments.php                    14      0
 tests/input/forbidden-functions.php                   6       0
-tests/input/inline_type_hint_assertions.php           7       0
+tests/input/inline_type_hint_assertions.php           10      0
 tests/input/LowCaseTypes.php                          2       0
 tests/input/namespaces-spacing.php                    7       0
 tests/input/NamingCamelCase.php                       9       0
@@ -50,9 +50,9 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     21      0
 ----------------------------------------------------------------------
-A TOTAL OF 432 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
+A TOTAL OF 435 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 365 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 368 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/inline_type_hint_assertions.php
+++ b/tests/fixed/inline_type_hint_assertions.php
@@ -24,3 +24,12 @@ $multipleScalarTypes = expression();
 assert(is_int($multipleScalarTypes) || is_float($multipleScalarTypes) || is_bool($multipleScalarTypes) || is_string($multipleScalarTypes) || is_array($multipleScalarTypes) || $multipleScalarTypes === null);
 
 /** @var Potato $variableThatIsNowhereToBeFound */
+
+$a = 1;
+assert(is_int($a) && $a > 0);
+
+$aa = null;
+assert((is_int($aa) && $aa > 0) || $aa === null);
+
+$aaa = 'string';
+assert(is_string($aaa) && $aaa !== '');

--- a/tests/input/inline_type_hint_assertions.php
+++ b/tests/input/inline_type_hint_assertions.php
@@ -24,3 +24,12 @@ $nullableType = expression();
 $multipleScalarTypes = expression();
 
 /** @var Potato $variableThatIsNowhereToBeFound */
+
+/** @var positive-int $a */
+$a = 1;
+
+/** @var positive-int|null $aa */
+$aa = null;
+
+/** @var non-empty-string $aaa */
+$aaa = 'string';

--- a/tests/php72-compatibility.patch
+++ b/tests/php72-compatibility.patch
@@ -14,7 +14,7 @@ index 5110131..53dada5 100644
 +tests/input/example-class.php                         41      0
  tests/input/forbidden-comments.php                    14      0
  tests/input/forbidden-functions.php                   6       0
- tests/input/inline_type_hint_assertions.php           7       0
+ tests/input/inline_type_hint_assertions.php           10      0
  tests/input/LowCaseTypes.php                          2       0
  tests/input/namespaces-spacing.php                    7       0
 -tests/input/NamingCamelCase.php                       9       0
@@ -51,11 +51,11 @@ index 5110131..53dada5 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 432 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
-+A TOTAL OF 385 ERRORS AND 0 WARNINGS WERE FOUND IN 42 FILES
+-A TOTAL OF 435 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
++A TOTAL OF 388 ERRORS AND 0 WARNINGS WERE FOUND IN 42 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 365 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 318 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 368 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 321 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  

--- a/tests/php73-compatibility.patch
+++ b/tests/php73-compatibility.patch
@@ -14,7 +14,7 @@ index 5110131..5616fdf 100644
 +tests/input/example-class.php                         41      0
  tests/input/forbidden-comments.php                    14      0
  tests/input/forbidden-functions.php                   6       0
- tests/input/inline_type_hint_assertions.php           7       0
+ tests/input/inline_type_hint_assertions.php           10      0
  tests/input/LowCaseTypes.php                          2       0
  tests/input/namespaces-spacing.php                    7       0
 -tests/input/NamingCamelCase.php                       9       0
@@ -52,11 +52,11 @@ index 5110131..5616fdf 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 432 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
-+A TOTAL OF 387 ERRORS AND 0 WARNINGS WERE FOUND IN 43 FILES
+-A TOTAL OF 435 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
++A TOTAL OF 390 ERRORS AND 0 WARNINGS WERE FOUND IN 43 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 365 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 320 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 368 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 323 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  

--- a/tests/php74-compatibility.patch
+++ b/tests/php74-compatibility.patch
@@ -14,7 +14,7 @@ index 5110131..dc2cf18 100644
 +tests/input/example-class.php                         44      0
  tests/input/forbidden-comments.php                    14      0
  tests/input/forbidden-functions.php                   6       0
- tests/input/inline_type_hint_assertions.php           7       0
+ tests/input/inline_type_hint_assertions.php           10      0
  tests/input/LowCaseTypes.php                          2       0
  tests/input/namespaces-spacing.php                    7       0
 -tests/input/NamingCamelCase.php                       9       0
@@ -50,11 +50,11 @@ index 5110131..dc2cf18 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 432 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
-+A TOTAL OF 396 ERRORS AND 0 WARNINGS WERE FOUND IN 43 FILES
+-A TOTAL OF 435 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
++A TOTAL OF 399 ERRORS AND 0 WARNINGS WERE FOUND IN 43 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 365 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 329 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 368 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 332 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -23,11 +23,11 @@ index 5110131..f0a3fc9 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 432 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
-+A TOTAL OF 426 ERRORS AND 0 WARNINGS WERE FOUND IN 45 FILES
+-A TOTAL OF 435 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
++A TOTAL OF 429 ERRORS AND 0 WARNINGS WERE FOUND IN 45 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 365 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 359 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 368 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 362 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  


### PR DESCRIPTION
- require slevomat/coding-standard v8.5.1

Follows up https://github.com/doctrine/coding-standard/pull/47 and adds support for more types