### PR TITLE
feat: handle blank lines between class properties

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -137,6 +137,12 @@
     </rule>
     <!-- Add one line around parent call in order to improve readability -->
     <rule ref="SlevomatCodingStandard.Classes.ParentCallSpacing"/>
+    <!-- Ensure that there are consistent blank lines between properties. -->
+    <rule ref="SlevomatCodingStandard.Classes.PropertySpacing">
+        <properties>
+            <property name="minLinesCountBeforeWithComment" value="0" />
+        </properties>
+    </rule>
     <!-- Require usage of ::class instead of __CLASS__, get_class(), get_class($this), get_called_class() and get_parent_class() -->
     <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
     <!-- https://github.com/slevomat/coding-standard#slevomatcodingstandardclassespropertydeclaration- -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -8,6 +8,7 @@ tests/input/arrow-functions-format.php                10      0
 tests/input/assignment-operators.php                  4       0
 tests/input/binary_operators.php                      9       0
 tests/input/class-references.php                      10      0
+tests/input/ClassPropertySpacing.php                  2       0
 tests/input/concatenation_spacing.php                 49      0
 tests/input/constants-no-lsb.php                      2       0
 tests/input/constants-var.php                         7       0
@@ -50,9 +51,9 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     21      0
 ----------------------------------------------------------------------
-A TOTAL OF 435 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
+A TOTAL OF 437 ERRORS AND 0 WARNINGS WERE FOUND IN 47 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 368 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 370 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/ClassPropertySpacing.php
+++ b/tests/fixed/ClassPropertySpacing.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spacing;
+
+final class ClassPropertySpacing
+{
+    public bool $foo;
+
+    /** @var string[] */
+    public array $bar;
+    /** @var string[] */
+    public array $baz;
+    public int $qux;
+
+    public int $fred;
+}

--- a/tests/input/ClassPropertySpacing.php
+++ b/tests/input/ClassPropertySpacing.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spacing;
+
+final class ClassPropertySpacing
+{
+    public bool $foo;
+
+
+    /** @var string[] */
+    public array $bar;
+    /** @var string[] */
+    public array $baz;
+    public int $qux;
+
+
+    public int $fred;
+}

--- a/tests/php72-compatibility.patch
+++ b/tests/php72-compatibility.patch
@@ -51,11 +51,11 @@ index 151bce4..0afca8c 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 435 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
-+A TOTAL OF 388 ERRORS AND 0 WARNINGS WERE FOUND IN 42 FILES
+-A TOTAL OF 437 ERRORS AND 0 WARNINGS WERE FOUND IN 47 FILES
++A TOTAL OF 390 ERRORS AND 0 WARNINGS WERE FOUND IN 43 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 368 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 321 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 370 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 323 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  

--- a/tests/php73-compatibility.patch
+++ b/tests/php73-compatibility.patch
@@ -52,11 +52,11 @@ index 151bce4..94718eb 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 435 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
-+A TOTAL OF 390 ERRORS AND 0 WARNINGS WERE FOUND IN 43 FILES
+-A TOTAL OF 437 ERRORS AND 0 WARNINGS WERE FOUND IN 47 FILES
++A TOTAL OF 392 ERRORS AND 0 WARNINGS WERE FOUND IN 44 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 368 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 323 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 370 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 325 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  

--- a/tests/php74-compatibility.patch
+++ b/tests/php74-compatibility.patch
@@ -50,11 +50,11 @@ index 151bce4..08a098f 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 435 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
-+A TOTAL OF 399 ERRORS AND 0 WARNINGS WERE FOUND IN 43 FILES
+-A TOTAL OF 437 ERRORS AND 0 WARNINGS WERE FOUND IN 47 FILES
++A TOTAL OF 401 ERRORS AND 0 WARNINGS WERE FOUND IN 44 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 368 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 332 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 370 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 334 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -23,11 +23,11 @@ index 151bce4..873691d 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 435 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
-+A TOTAL OF 429 ERRORS AND 0 WARNINGS WERE FOUND IN 45 FILES
+-A TOTAL OF 437 ERRORS AND 0 WARNINGS WERE FOUND IN 47 FILES
++A TOTAL OF 431 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 368 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 362 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 370 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 364 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  


### PR DESCRIPTION
[The settings is](https://github.com/slevomat/coding-standard/blob/f32937dc41b587f3500efed1dbca2f82aa519373/SlevomatCodingStandard/Sniffs/Classes/AbstractPropertyAndConstantSpacing.php):

```php
$minLinesCountBeforeWithComment = 1;
$maxLinesCountBeforeWithComment = 1;
$minLinesCountBeforeWithoutComment = 0;
$maxLinesCountBeforeWithoutComment = 1;
```