### PR TITLE
Adjust expectations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
-        "slevomat/coding-standard": "^8.2",
+        "slevomat/coding-standard": "^8.6.2",
         "squizlabs/php_codesniffer": "^3.7"
     },
     "config": {

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -10,7 +10,7 @@ tests/input/binary_operators.php                      9       0
 tests/input/class-references.php                      10      0
 tests/input/concatenation_spacing.php                 49      0
 tests/input/constants-no-lsb.php                      2       0
-tests/input/constants-var.php                         7       0
+tests/input/constants-var.php                         6       0
 tests/input/ControlStructures.php                     28      0
 tests/input/doc-comment-spacing.php                   11      0
 tests/input/duplicate-assignment-variable.php         1       0
@@ -50,7 +50,7 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     21      0
 ----------------------------------------------------------------------
-A TOTAL OF 429 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
+A TOTAL OF 428 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 364 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------

--- a/tests/php72-compatibility.patch
+++ b/tests/php72-compatibility.patch
@@ -2,7 +2,7 @@ diff --git a/tests/expected_report.txt b/tests/expected_report.txt
 index 5110131..53dada5 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
-@@ -14,26 +14,23 @@ tests/input/constants-var.php                         7       0
+@@ -14,26 +14,23 @@ tests/input/constants-var.php                         6       0
  tests/input/ControlStructures.php                     28      0
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
@@ -51,8 +51,8 @@ index 5110131..53dada5 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 429 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
-+A TOTAL OF 382 ERRORS AND 0 WARNINGS WERE FOUND IN 42 FILES
+-A TOTAL OF 428 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
++A TOTAL OF 381 ERRORS AND 0 WARNINGS WERE FOUND IN 42 FILES
  ----------------------------------------------------------------------
 -PHPCBF CAN FIX 364 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 317 OF THESE SNIFF VIOLATIONS AUTOMATICALLY

--- a/tests/php73-compatibility.patch
+++ b/tests/php73-compatibility.patch
@@ -2,7 +2,7 @@ diff --git a/tests/expected_report.txt b/tests/expected_report.txt
 index 5110131..5616fdf 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
-@@ -14,26 +14,23 @@ tests/input/constants-var.php                         7       0
+@@ -14,26 +14,23 @@ tests/input/constants-var.php                         6       0
  tests/input/ControlStructures.php                     28      0
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
@@ -52,8 +52,8 @@ index 5110131..5616fdf 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 429 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
-+A TOTAL OF 384 ERRORS AND 0 WARNINGS WERE FOUND IN 43 FILES
+-A TOTAL OF 428 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
++A TOTAL OF 383 ERRORS AND 0 WARNINGS WERE FOUND IN 43 FILES
  ----------------------------------------------------------------------
 -PHPCBF CAN FIX 364 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 319 OF THESE SNIFF VIOLATIONS AUTOMATICALLY

--- a/tests/php74-compatibility.patch
+++ b/tests/php74-compatibility.patch
@@ -2,7 +2,7 @@ diff --git a/tests/expected_report.txt b/tests/expected_report.txt
 index 5110131..dc2cf18 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
-@@ -14,26 +14,23 @@ tests/input/constants-var.php                         7       0
+@@ -14,26 +14,23 @@ tests/input/constants-var.php                         6       0
  tests/input/ControlStructures.php                     28      0
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
@@ -50,8 +50,8 @@ index 5110131..dc2cf18 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 429 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
-+A TOTAL OF 393 ERRORS AND 0 WARNINGS WERE FOUND IN 43 FILES
+-A TOTAL OF 428 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
++A TOTAL OF 392 ERRORS AND 0 WARNINGS WERE FOUND IN 43 FILES
  ----------------------------------------------------------------------
 -PHPCBF CAN FIX 364 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 328 OF THESE SNIFF VIOLATIONS AUTOMATICALLY

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -23,8 +23,8 @@ index 5110131..f0a3fc9 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 429 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
-+A TOTAL OF 423 ERRORS AND 0 WARNINGS WERE FOUND IN 45 FILES
+-A TOTAL OF 428 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
++A TOTAL OF 422 ERRORS AND 0 WARNINGS WERE FOUND IN 45 FILES
  ----------------------------------------------------------------------
 -PHPCBF CAN FIX 364 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 358 OF THESE SNIFF VIOLATIONS AUTOMATICALLY


### PR DESCRIPTION
Upstream package has fixed a false positive with `self::CONSTANT`

Here is how the false positive looked like

```
   9 | ERROR | [ ] Invalid inline documentation comment format "@var int", expected "@var type $variable Optional description".
     |       |     (SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.InvalidFormat)
```
It was about these lines:
```php
/** @var int */
const FOO = 123;
```