### PR TITLE
String interpolation: don't suggest `sprintf()`

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -599,9 +599,6 @@
     </rule>
     <!-- Forbid strings in `"` unless necessary -->
     <rule ref="Squiz.Strings.DoubleQuoteUsage"/>
-    <rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
-        <message>Variable "%s" not allowed in double quoted string; use sprintf() or concatenation instead</message>
-    </rule>
     <!-- Forbid braces around string in `echo` -->
     <rule ref="Squiz.Strings.EchoedStrings"/>
     <!-- Forbid spaces in type casts -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -40,7 +40,7 @@ tests/input/semicolon_spacing.php                     3       0
 tests/input/single-line-array-spacing.php             5       0
 tests/input/spread-operator.php                       6       0
 tests/input/static-closures.php                       1       0
-tests/input/strings.php                               1       0
+tests/input/strings.php                               3       0
 tests/input/superfluous-naming.php                    11      0
 tests/input/test-case.php                             8       0
 tests/input/trailing_comma_on_array.php               1       0
@@ -52,9 +52,9 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     21      0
 ----------------------------------------------------------------------
-A TOTAL OF 451 ERRORS AND 0 WARNINGS WERE FOUND IN 48 FILES
+A TOTAL OF 453 ERRORS AND 0 WARNINGS WERE FOUND IN 48 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 374 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 375 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/strings.php
+++ b/tests/fixed/strings.php
@@ -7,3 +7,13 @@ namespace Strings;
 $doc = <<<'TEXT'
 text without special chars
 TEXT;
+
+$interpolated = <<<TEXT
+HEREDOC with interpolation like $doc is fine.
+TEXT;
+
+echo 'This should appear in single quotes.';
+
+echo "This string\tmay appear\nin double quotes.";
+
+echo "String interpolation like $doc should be avoided.";

--- a/tests/input/strings.php
+++ b/tests/input/strings.php
@@ -7,3 +7,13 @@ namespace Strings;
 $doc = <<<TEXT
 text without special chars
 TEXT;
+
+$interpolated = <<<TEXT
+HEREDOC with interpolation like $doc is fine.
+TEXT;
+
+echo "This should appear in single quotes.";
+
+echo "This string\tmay appear\nin double quotes.";
+
+echo "String interpolation like $doc should be avoided.";

--- a/tests/php72-compatibility.patch
+++ b/tests/php72-compatibility.patch
@@ -55,11 +55,11 @@ index d1e1fad..ea3b611 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 451 ERRORS AND 0 WARNINGS WERE FOUND IN 48 FILES
-+A TOTAL OF 404 ERRORS AND 0 WARNINGS WERE FOUND IN 44 FILES
+-A TOTAL OF 453 ERRORS AND 0 WARNINGS WERE FOUND IN 48 FILES
++A TOTAL OF 406 ERRORS AND 0 WARNINGS WERE FOUND IN 44 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 374 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 327 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 375 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 328 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  

--- a/tests/php73-compatibility.patch
+++ b/tests/php73-compatibility.patch
@@ -56,11 +56,11 @@ index d1e1fad..9a78bc1 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 451 ERRORS AND 0 WARNINGS WERE FOUND IN 48 FILES
-+A TOTAL OF 406 ERRORS AND 0 WARNINGS WERE FOUND IN 45 FILES
+-A TOTAL OF 453 ERRORS AND 0 WARNINGS WERE FOUND IN 48 FILES
++A TOTAL OF 408 ERRORS AND 0 WARNINGS WERE FOUND IN 45 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 374 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 329 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 375 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 330 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  

--- a/tests/php74-compatibility.patch
+++ b/tests/php74-compatibility.patch
@@ -54,11 +54,11 @@ index d1e1fad..ed67841 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 451 ERRORS AND 0 WARNINGS WERE FOUND IN 48 FILES
-+A TOTAL OF 415 ERRORS AND 0 WARNINGS WERE FOUND IN 45 FILES
+-A TOTAL OF 453 ERRORS AND 0 WARNINGS WERE FOUND IN 48 FILES
++A TOTAL OF 417 ERRORS AND 0 WARNINGS WERE FOUND IN 45 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 374 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 338 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 375 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 339 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -29,11 +29,11 @@ index d1e1fad..71022c4 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 451 ERRORS AND 0 WARNINGS WERE FOUND IN 48 FILES
-+A TOTAL OF 445 ERRORS AND 0 WARNINGS WERE FOUND IN 47 FILES
+-A TOTAL OF 453 ERRORS AND 0 WARNINGS WERE FOUND IN 48 FILES
++A TOTAL OF 447 ERRORS AND 0 WARNINGS WERE FOUND IN 47 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 374 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 368 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 375 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 369 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  


### PR DESCRIPTION
Our coding standard currently forbids string interpolation and recommends `sprintf()` or concatenation as alternatives. However, in PHP 7 string interpolation [has been optimized](https://blog.blackfire.io/php-7-performance-improvements-encapsed-strings-optimization.html) and might outperform both alternatives on a hot path.

Of course, we're talking about micro-optimization here and I can totally understand that projects want to stick to `sprintf()` for the sake of consistency. But I believe that the general recommendation to avoid string interpolation is not up to date anymore.

~~My proposal is to allow double-quoted interpolated strings.~~

Update: The PR now removes the suggestion to use `sprintf()` instead of interpolation.