### PR TITLE
Disallow string property fetch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0.0",
-        "slevomat/coding-standard": "^8.6.2",
+        "slevomat/coding-standard": "^8.10.0",
         "squizlabs/php_codesniffer": "^3.7"
     },
     "config": {

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -136,6 +136,8 @@
     <rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants"/>
     <!-- Forbid more than one constant declared per statement -->
     <rule ref="SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition"/>
+    <!-- Forbid string expression property fetch ($foo->{'bar'}) -->
+    <rule ref="SlevomatCodingStandard.Classes.DisallowStringExpressionPropertyFetch"/>
     <!-- Forbid empty lines around type declarations -->
     <rule ref="SlevomatCodingStandard.Classes.EmptyLinesAroundClassBraces">
         <properties>

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -40,6 +40,7 @@ tests/input/semicolon_spacing.php                     3       0
 tests/input/single-line-array-spacing.php             5       0
 tests/input/spread-operator.php                       6       0
 tests/input/static-closures.php                       1       0
+tests/input/string_property_fetch.php                 1       0
 tests/input/strings.php                               3       0
 tests/input/superfluous-naming.php                    11      0
 tests/input/test-case.php                             8       0
@@ -52,9 +53,9 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     21      0
 ----------------------------------------------------------------------
-A TOTAL OF 453 ERRORS AND 0 WARNINGS WERE FOUND IN 48 FILES
+A TOTAL OF 454 ERRORS AND 0 WARNINGS WERE FOUND IN 49 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 375 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 376 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/string_property_fetch.php
+++ b/tests/fixed/string_property_fetch.php
@@ -1,0 +1,6 @@
+<?php
+
+declare(strict_types=1);
+
+$a    = new stdClass();
+$a->b = 'hi';

--- a/tests/input/string_property_fetch.php
+++ b/tests/input/string_property_fetch.php
@@ -1,0 +1,6 @@
+<?php
+
+declare(strict_types=1);
+
+$a        = new stdClass();
+$a->{'b'} = 'hi';

--- a/tests/php72-compatibility.patch
+++ b/tests/php72-compatibility.patch
@@ -41,7 +41,7 @@ index d1e1fad..ea3b611 100644
  tests/input/semicolon_spacing.php                     3       0
  tests/input/single-line-array-spacing.php             5       0
  tests/input/spread-operator.php                       6       0
-@@ -44,17 +41,16 @@ tests/input/strings.php                               1       0
+@@ -43,17 +42,16 @@ tests/input/strings.php                               1       0
  tests/input/superfluous-naming.php                    11      0
  tests/input/test-case.php                             8       0
  tests/input/trailing_comma_on_array.php               1       0
@@ -55,11 +55,11 @@ index d1e1fad..ea3b611 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 453 ERRORS AND 0 WARNINGS WERE FOUND IN 48 FILES
-+A TOTAL OF 406 ERRORS AND 0 WARNINGS WERE FOUND IN 44 FILES
+-A TOTAL OF 454 ERRORS AND 0 WARNINGS WERE FOUND IN 49 FILES
++A TOTAL OF 407 ERRORS AND 0 WARNINGS WERE FOUND IN 45 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 375 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 328 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 376 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 329 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  

--- a/tests/php73-compatibility.patch
+++ b/tests/php73-compatibility.patch
@@ -41,7 +41,7 @@ index d1e1fad..9a78bc1 100644
  tests/input/semicolon_spacing.php                     3       0
  tests/input/single-line-array-spacing.php             5       0
  tests/input/spread-operator.php                       6       0
-@@ -44,17 +41,17 @@ tests/input/strings.php                               1       0
+@@ -43,17 +42,17 @@ tests/input/strings.php                               1       0
  tests/input/superfluous-naming.php                    11      0
  tests/input/test-case.php                             8       0
  tests/input/trailing_comma_on_array.php               1       0
@@ -56,11 +56,11 @@ index d1e1fad..9a78bc1 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 453 ERRORS AND 0 WARNINGS WERE FOUND IN 48 FILES
-+A TOTAL OF 408 ERRORS AND 0 WARNINGS WERE FOUND IN 45 FILES
+-A TOTAL OF 454 ERRORS AND 0 WARNINGS WERE FOUND IN 49 FILES
++A TOTAL OF 409 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 375 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 330 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 376 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 331 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  

--- a/tests/php74-compatibility.patch
+++ b/tests/php74-compatibility.patch
@@ -39,7 +39,7 @@ index d1e1fad..ed67841 100644
  tests/input/semicolon_spacing.php                     3       0
  tests/input/single-line-array-spacing.php             5       0
  tests/input/spread-operator.php                       6       0
-@@ -44,17 +41,17 @@ tests/input/strings.php                               1       0
+@@ -43,17 +42,17 @@ tests/input/strings.php                               1       0
  tests/input/superfluous-naming.php                    11      0
  tests/input/test-case.php                             8       0
  tests/input/trailing_comma_on_array.php               1       0
@@ -54,11 +54,11 @@ index d1e1fad..ed67841 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 453 ERRORS AND 0 WARNINGS WERE FOUND IN 48 FILES
-+A TOTAL OF 417 ERRORS AND 0 WARNINGS WERE FOUND IN 45 FILES
+-A TOTAL OF 454 ERRORS AND 0 WARNINGS WERE FOUND IN 49 FILES
++A TOTAL OF 418 ERRORS AND 0 WARNINGS WERE FOUND IN 46 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 375 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 339 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 376 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 340 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -25,15 +25,15 @@ index d1e1fad..71022c4 100644
  tests/input/return_type_on_closures.php               26      0
  tests/input/return_type_on_methods.php                22      0
  tests/input/semicolon_spacing.php                     3       0
-@@ -52,9 +51,9 @@ tests/input/use-ordering.php                          1       0
+@@ -51,9 +52,9 @@ tests/input/use-ordering.php                          1       0
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 453 ERRORS AND 0 WARNINGS WERE FOUND IN 48 FILES
-+A TOTAL OF 447 ERRORS AND 0 WARNINGS WERE FOUND IN 47 FILES
+-A TOTAL OF 454 ERRORS AND 0 WARNINGS WERE FOUND IN 49 FILES
++A TOTAL OF 448 ERRORS AND 0 WARNINGS WERE FOUND IN 48 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 375 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 369 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 376 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 370 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  
  


### PR DESCRIPTION
While we're unlikely to manually write such things, there are custom rectors I've been writing that do so, and massively.

I wrote some tests, although I'm unsure why we write tests at all, since the rules have already been tested.