### PR TITLE
Set Bash explicitly as default shell in `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 .PHONY: test test-report test-fix update-compatibility-patch
 
 test: test-report test-fix


### PR DESCRIPTION
GNU `make` uses `/bin/sh` by default if the `SHELL` variable is not set to a different value (see [Choosing the Shell](https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html)).

In my environment (and in many of my previous _bashism_ incursions), I found myself fighting with syntax issues derived from the fact that `[ x == y ]` does not work with `sh`:

```shell
/bin/sh: 1: [: unexpected operator
```

See:
* https://unix.stackexchange.com/a/72042
* https://stackoverflow.com/a/18102991

BTW, I've opted to set `/bin/bash` as the default shell instead of changing the script syntax to make it compatible with `/bin/sh`, because the shebangs at the `bin/` directory are already using `/bin/bash`.