### PR TITLE
Lint shell scripts with ShellCheck

### DIFF
--- a/.github/workflows/ci-shell-scripts.yml
+++ b/.github/workflows/ci-shell-scripts.yml
@@ -1,0 +1,33 @@
+# https://help.github.com/en/categories/automating-your-workflow-with-github-actions
+
+name: "Continuous Integration for shell scripts"
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/ci-shell-scripts.yml"
+      - "bin/**"
+  push:
+    branches:
+      - "*.*.x"
+    paths:
+      - ".github/workflows/ci-shell-scripts.yml"
+      - "bin/**"
+  schedule:
+    - cron: "0 17 * * *"
+
+jobs:
+  lint-shell-scripts:
+    name: "Lint shell scripts"
+
+    runs-on: "ubuntu-22.04"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+
+      - name: "Lint shell scripts with ShellCheck"
+        uses: "ludeeus/action-shellcheck@2.0.0"
+        with:
+          scandir: "./bin"
+          check_together: "yes"


### PR DESCRIPTION
It seems that ShellCheck was already used in this project:
https://github.com/doctrine/coding-standard/blob/94bc305fb858ea58e6aa8829cff6c9677779203a/bin/test-report#L10

BTW, I'd like to discuss for a future PR if we should provide this tool and GNU make through the built-in Docker image (as this approach may ensure all the required tools are also available in the local environment).
https://github.com/doctrine/coding-standard/blob/94bc305fb858ea58e6aa8829cff6c9677779203a/.docker/validate-against-schema/Dockerfile#L1