### PR TITLE
Remove duplicate `RequireOneLineDocComment` rule

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -252,8 +252,6 @@
     </rule>
     <!-- Report invalid format of inline phpDocs with @var -->
     <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
-    <!-- Require comments with single line written as one-liners -->
-    <rule ref="SlevomatCodingStandard.Commenting.RequireOneLineDocComment"/>
     <!-- Forbid assignments in conditions -->
     <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
     <!-- Require consistent spacing for block structures -->


### PR DESCRIPTION
I have removed the first occurrence of the `SlevomatCodingStandard.Commenting.RequireOneLineDocComment` rule as it was most recently changed (in #294, from what I can tell to catch more instances of one-line doc comments, however, as we see now the new rule was already introduced in #252). The second occurrence also appears to fit better with the surrounding rules.

This fixes #318.