### PR TITLE
test: increase errors in PropertyDeclaration

### DIFF
--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -34,7 +34,7 @@ tests/input/null_coalesce_equal_operator.php          5       0
 tests/input/null_coalesce_operator.php                3       0
 tests/input/null_safe_operator.php                    1       0
 tests/input/optimized-functions.php                   1       0
-tests/input/PropertyDeclaration.php                   14      0
+tests/input/PropertyDeclaration.php                   16      0
 tests/input/return_type_on_closures.php               26      0
 tests/input/return_type_on_methods.php                22      0
 tests/input/semicolon_spacing.php                     3       0
@@ -54,9 +54,9 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     21      0
 ----------------------------------------------------------------------
-A TOTAL OF 464 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
+A TOTAL OF 466 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 380 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 382 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/php72-compatibility.patch
+++ b/tests/php72-compatibility.patch
@@ -37,7 +37,7 @@ index a646ff6..84c9474 100644
  tests/input/null_coalesce_operator.php                3       0
 -tests/input/null_safe_operator.php                    1       0
  tests/input/optimized-functions.php                   1       0
--tests/input/PropertyDeclaration.php                   14      0
+-tests/input/PropertyDeclaration.php                   16      0
 -tests/input/return_type_on_closures.php               26      0
 -tests/input/return_type_on_methods.php                22      0
 +tests/input/PropertyDeclaration.php                   6       0
@@ -60,10 +60,10 @@ index a646ff6..84c9474 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 464 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
+-A TOTAL OF 466 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
 +A TOTAL OF 415 ERRORS AND 2 WARNINGS WERE FOUND IN 46 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 380 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 382 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 331 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  

--- a/tests/php73-compatibility.patch
+++ b/tests/php73-compatibility.patch
@@ -28,7 +28,7 @@ index d1e1fad..9a78bc1 100644
  tests/input/null_coalesce_operator.php                3       0
 -tests/input/null_safe_operator.php                    1       0
  tests/input/optimized-functions.php                   1       0
--tests/input/PropertyDeclaration.php                   14      0
+-tests/input/PropertyDeclaration.php                   16      0
 -tests/input/return_type_on_closures.php               26      0
 -tests/input/return_type_on_methods.php                22      0
 +tests/input/PropertyDeclaration.php                   6       0
@@ -52,10 +52,10 @@ index d1e1fad..9a78bc1 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 464 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
+-A TOTAL OF 466 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
 +A TOTAL OF 419 ERRORS AND 2 WARNINGS WERE FOUND IN 47 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 380 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 382 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 335 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  

--- a/tests/php74-compatibility.patch
+++ b/tests/php74-compatibility.patch
@@ -26,7 +26,7 @@ index d1e1fad..ed67841 100644
  tests/input/null_coalesce_operator.php                3       0
 -tests/input/null_safe_operator.php                    1       0
  tests/input/optimized-functions.php                   1       0
--tests/input/PropertyDeclaration.php                   14      0
+-tests/input/PropertyDeclaration.php                   16      0
 -tests/input/return_type_on_closures.php               26      0
 -tests/input/return_type_on_methods.php                22      0
 +tests/input/PropertyDeclaration.php                   6       0
@@ -50,10 +50,10 @@ index d1e1fad..ed67841 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 464 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
+-A TOTAL OF 466 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
 +A TOTAL OF 428 ERRORS AND 2 WARNINGS WERE FOUND IN 47 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 380 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 382 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 344 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -14,7 +14,7 @@ index d1e1fad..71022c4 100644
  tests/input/null_coalesce_operator.php                3       0
  tests/input/null_safe_operator.php                    1       0
  tests/input/optimized-functions.php                   1       0
--tests/input/PropertyDeclaration.php                   14      0
+-tests/input/PropertyDeclaration.php                   16      0
 +tests/input/PropertyDeclaration.php                   11      0
  tests/input/return_type_on_closures.php               26      0
  tests/input/return_type_on_methods.php                22      0
@@ -23,10 +23,10 @@ index d1e1fad..71022c4 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 464 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
+-A TOTAL OF 466 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
 +A TOTAL OF 458 ERRORS AND 2 WARNINGS WERE FOUND IN 49 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 380 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 382 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 374 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
  


### PR DESCRIPTION
Probably caused by update in slevomat or squizlabs

I don't really want to dig what's new, all are legit finds:

```
vendor/bin/phpcs `find tests/input/PropertyDeclaration.php`
WARNING: The PHPCS Coding Standards for doctrine/coding-standards standard uses 1 deprecated sniff
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SlevomatCodingStandard.TypeHints.UnionTypeHintFormat
   This sniff has been deprecated since Slevomat Coding Standard 8.16.0 and will be removed in Slevomat Coding Standard 9.0.0. Use SlevomatCodingStandard.TypeHints.DNFTypeHintFormat instead.

Deprecated sniffs are still run, but will stop working at some point in the future.

E 1 / 1 (100%)

FILE: tests/input/PropertyDeclaration.php
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 16 ERRORS AFFECTING 5 LINES
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  9 | ERROR | [x] Equals sign not aligned correctly; expected 1 space but found 2 spaces (Generic.Formatting.MultipleStatementAlignment.Incorrect)
 10 | ERROR | [x] There must be exactly one space between type hint and property $stringProperty. (SlevomatCodingStandard.Classes.PropertyDeclaration.MultipleSpacesBetweenTypeHintAndProperty)
 10 | ERROR | [x] There must be 1 space after the property type declaration; 2 found (PSR2.Classes.PropertyDeclaration.SpacingAfterType)
 11 | ERROR | [x] Scope keyword "public" must be followed by a single space; found 2 (Squiz.WhiteSpace.ScopeKeywordSpacing.Incorrect)
 11 | ERROR | [x] There must be exactly one space before type hint of property $intProperty. (SlevomatCodingStandard.Classes.PropertyDeclaration.MultipleSpacesBeforeTypeHint)
 12 | ERROR | [x] Usage of short nullable type hint in "?string" is disallowed. (SlevomatCodingStandard.TypeHints.UnionTypeHintFormat.DisallowedShortNullable)
 12 | ERROR | [x] There must be no whitespace between type hint nullability symbol and type hint of property $nullableString. (SlevomatCodingStandard.Classes.PropertyDeclaration.WhitespaceAfterNullabilitySymbol)
 15 | ERROR | [x] Expected 1 space after visibility modifier "public"; 2 found (Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterVisbility)
 15 | ERROR | [x] Scope keyword "public" must be followed by a single space; found 2 (Squiz.WhiteSpace.ScopeKeywordSpacing.Incorrect)
 15 | ERROR | [x] There must be exactly one space between modifiers of property $foo. (SlevomatCodingStandard.Classes.PropertyDeclaration.MultipleSpacesBetweenModifiers)
 15 | ERROR | [x] Expected 1 space after readonly modifier; 2 found (Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterReadonly)
 15 | ERROR | [x] Scope keyword "readonly" must be followed by a single space; found 2 (Squiz.WhiteSpace.ScopeKeywordSpacing.Incorrect)
 15 | ERROR | [x] There must be exactly one space before type hint of property $foo. (SlevomatCodingStandard.Classes.PropertyDeclaration.MultipleSpacesBeforeTypeHint)
 15 | ERROR | [x] Expected 1 space between type hint and argument "$foo"; 2 found (Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterHint)
 15 | ERROR | [x] There must be exactly one space between parameter type hint and parameter $foo. (SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing.MultipleSpacesBetweenTypeHintAndParameter)
 15 | ERROR | [x] There must be exactly one space between type hint and property $foo. (SlevomatCodingStandard.Classes.PropertyDeclaration.MultipleSpacesBetweenTypeHintAndProperty)
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 16 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Time: 95ms; Memory: 12MB
```