### PR TITLE
Address Sniff deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0.0",
-        "slevomat/coding-standard": "^8.11",
+        "slevomat/coding-standard": "^8.16",
         "squizlabs/php_codesniffer": "^3.7"
     },
     "config": {

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -481,9 +481,9 @@
         </properties>
     </rule>
     <!-- Define unions style -->
-    <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat">
+    <rule ref="SlevomatCodingStandard.TypeHints.DNFTypeHintFormat">
         <properties>
-            <property name="withSpaces" value="no" />
+            <property name="withSpacesAroundOperators" value="no" />
             <property name="shortNullable" value="no" />
             <property name="nullPosition" value="last" />
         </properties>


### PR DESCRIPTION
`UnionTypeHintFormatSniff` is deprecated in favor of `DNFTypeHintFormat`

I'm deliberately not setting `withSpacesInsideParentheses` so as not to incur any breaking change.

See https://github.com/slevomat/coding-standard/commit/5e3b792def632494fde23e167c949f6371d2abca See https://github.com/slevomat/coding-standard/blob/master/doc/type-hints.md#slevomatcodingstandardtypehintsdnftypehintformat- .