### PR TITLE
fix: update rule for language construct spacing

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -623,7 +623,7 @@
     <!-- Require there be no space between increment/decrement operator and its operand -->
     <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
     <!-- Require space after language constructs -->
-    <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
+    <rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
     <!-- Require space around logical operators -->
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
     <!-- Forbid spaces around `->` operator -->


### PR DESCRIPTION
-  Squiz.WhiteSpace.LanguageConstructSpacing This sniff has been deprecated since v3.3.0 and will be removed in v4.0.0. Use the Generic.WhiteSpace.LanguageConstructSpacing sniff instead.