### PR TITLE
Remove PHPCS workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,39 +11,6 @@ on:
     - cron: "0 17 * * *"
 
 jobs:
-  coding-standards:
-    name: "Coding Standards"
-
-    runs-on: "ubuntu-22.04"
-
-    strategy:
-      matrix:
-        php-version:
-          - "7.4"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v5"
-
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          coverage: "none"
-          php-version: "${{ matrix.php-version }}"
-
-      - name: "Cache dependencies installed with composer"
-        uses: "actions/cache@v4"
-        with:
-          path: "~/.composer/cache"
-          key: "php-${{ matrix.php-version }}-composer-${{ hashFiles('composer.json') }}"
-          restore-keys: "php-${{ matrix.php-version }}-composer-"
-
-      - name: "Install dependencies with composer"
-        run: "composer update --no-interaction --no-progress --no-suggest"
-
-      - name: "Run squizlabs/php_codesniffer"
-        run: "vendor/bin/phpcs"
-
   validate-against-schema:
     name: "Validate against schema"
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd"
 >
-    <description>Check the code of the sniffs in doctrine/coding-standards.</description>
+    <description>Used by the binaries inside bin/</description>
 
     <arg name="basepath" value="." />
     <arg name="extensions" value="php" />
@@ -17,6 +17,4 @@
     <arg value="s" />
 
     <rule ref="Doctrine" />
-
-    <file>lib</file>
 </ruleset>


### PR DESCRIPTION
It shouldn't have been introduced in the first place, as there were no files to check inside `lib` anymore.