### PR TITLE
feat(rules): require one doc comment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0.0",
-        "slevomat/coding-standard": "^8.23",
+        "slevomat/coding-standard": "^8.24",
         "squizlabs/php_codesniffer": "^4"
     },
     "config": {

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -254,6 +254,8 @@
     </rule>
     <!-- Report invalid format of inline phpDocs with @var -->
     <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
+    <!-- Require only one doc comment per symbol -->
+    <rule ref="SlevomatCodingStandard.Commenting.RequireOneDocComment"/>
     <!-- Forbid assignments in conditions -->
     <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
     <!-- Require consistent spacing for block structures -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -35,6 +35,7 @@ tests/input/null_coalesce_operator.php                3       0
 tests/input/null_safe_operator.php                    1       0
 tests/input/optimized-functions.php                   1       0
 tests/input/PropertyDeclaration.php                   16      0
+tests/input/RequireOneDocComment.php                  1       0
 tests/input/return_type_on_closures.php               26      0
 tests/input/return_type_on_methods.php                22      0
 tests/input/semicolon_spacing.php                     3       0
@@ -54,7 +55,7 @@ tests/input/use-ordering.php                          1       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     21      0
 ----------------------------------------------------------------------
-A TOTAL OF 476 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
+A TOTAL OF 477 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
 ----------------------------------------------------------------------
 PHPCBF CAN FIX 391 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------

--- a/tests/fixed/RequireOneDocComment.php
+++ b/tests/fixed/RequireOneDocComment.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RequireOneDocComment;
+
+/**
+ * First doc comment.
+ */
+/**
+ * Second doc comment.
+ */
+class RequireOneDocComment
+{
+}

--- a/tests/input/RequireOneDocComment.php
+++ b/tests/input/RequireOneDocComment.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RequireOneDocComment;
+
+/**
+ * First doc comment.
+ */
+/**
+ * Second doc comment.
+ */
+class RequireOneDocComment
+{
+}

--- a/tests/php74-compatibility.patch
+++ b/tests/php74-compatibility.patch
@@ -2,7 +2,7 @@ diff --git a/tests/expected_report.txt b/tests/expected_report.txt
 index 8547171..f01ece0 100644
 --- a/tests/expected_report.txt
 +++ b/tests/expected_report.txt
-@@ -13,30 +13,27 @@ tests/input/class-references.php                      10      2
+@@ -13,31 +13,28 @@ tests/input/class-references.php                      10      2
  tests/input/ClassPropertySpacing.php                  2       0
  tests/input/concatenation_spacing.php                 49      0
  tests/input/constants-no-lsb.php                      2       0
@@ -32,15 +32,16 @@ index 8547171..f01ece0 100644
 -tests/input/null_safe_operator.php                    1       0
  tests/input/optimized-functions.php                   1       0
 -tests/input/PropertyDeclaration.php                   16      0
++tests/input/PropertyDeclaration.php                   6       0
+ tests/input/RequireOneDocComment.php                  1       0
 -tests/input/return_type_on_closures.php               26      0
 -tests/input/return_type_on_methods.php                22      0
-+tests/input/PropertyDeclaration.php                   6       0
 +tests/input/return_type_on_closures.php               21      0
 +tests/input/return_type_on_methods.php                17      0
  tests/input/semicolon_spacing.php                     3       0
  tests/input/single-line-array-spacing.php             5       0
  tests/input/spread-operator.php                       6       0
-@@ -46,17 +43,17 @@ tests/input/strings.php                               3       0
+@@ -47,15 +44,15 @@ tests/input/strings.php                               3       0
  tests/input/superfluous-naming.php                    11      0
  tests/input/test-case.php                             8       0
  tests/input/trailing_comma_on_array.php               1       0
@@ -55,14 +56,12 @@ index 8547171..f01ece0 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 476 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
-+A TOTAL OF 429 ERRORS AND 2 WARNINGS WERE FOUND IN 47 FILES
+-A TOTAL OF 477 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
++A TOTAL OF 430 ERRORS AND 2 WARNINGS WERE FOUND IN 48 FILES
  ----------------------------------------------------------------------
 -PHPCBF CAN FIX 391 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 345 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
- 
- 
 diff --git a/tests/fixed/ControlStructures.php b/tests/fixed/ControlStructures.php
 index 480e419..a653086 100644
 --- a/tests/fixed/ControlStructures.php

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -18,27 +18,26 @@ index 9b19b9e..760ee4a 100644
  tests/input/Exceptions.php                            1       0
  tests/input/forbidden-comments.php                    14      0
  tests/input/forbidden-functions.php                   6       0
-@@ -34,7 +33,7 @@ tests/input/null_coalesce_equal_operator.php          5       0
+@@ -34,8 +33,8 @@ tests/input/null_coalesce_equal_operator.php          5       0
  tests/input/null_coalesce_operator.php                3       0
  tests/input/null_safe_operator.php                    1       0
  tests/input/optimized-functions.php                   1       0
 -tests/input/PropertyDeclaration.php                   16      0
 +tests/input/PropertyDeclaration.php                   11      0
+ tests/input/RequireOneDocComment.php                  1       0
  tests/input/return_type_on_closures.php               26      0
  tests/input/return_type_on_methods.php                22      0
  tests/input/semicolon_spacing.php                     3       0
-@@ -54,9 +53,9 @@ tests/input/use-ordering.php                          1       0
+@@ -55,7 +54,7 @@ tests/input/use-ordering.php                          1       0
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 476 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
-+A TOTAL OF 459 ERRORS AND 2 WARNINGS WERE FOUND IN 49 FILES
+-A TOTAL OF 477 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
++A TOTAL OF 460 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
  ----------------------------------------------------------------------
 -PHPCBF CAN FIX 391 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 375 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
- 
- 
 diff --git a/tests/fixed/ExampleBackedEnum.php b/tests/fixed/ExampleBackedEnum.php
 index fd701eb..fe54eb9 100644
 --- a/tests/fixed/ExampleBackedEnum.php

--- a/tests/php81-compatibility.patch
+++ b/tests/php81-compatibility.patch
@@ -17,18 +17,16 @@ index 8547171..a7a42fa 100644
  tests/input/ExampleBackedEnum.php                     5       0
  tests/input/Exceptions.php                            1       0
  tests/input/forbidden-comments.php                    14      0
-@@ -54,9 +54,9 @@ tests/input/use-ordering.php                          1       0
+@@ -55,7 +55,7 @@ tests/input/use-ordering.php                          1       0
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 476 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
-+A TOTAL OF 469 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
+-A TOTAL OF 477 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
++A TOTAL OF 470 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
  ----------------------------------------------------------------------
 -PHPCBF CAN FIX 391 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 385 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
- 
- 
 diff --git a/tests/fixed/constants-var.php b/tests/fixed/constants-var.php
 index f10c235..d4268cb 100644
 --- a/tests/fixed/constants-var.php

--- a/tests/php82-compatibility.patch
+++ b/tests/php82-compatibility.patch
@@ -17,18 +17,16 @@ index 8547171..a7a42fa 100644
  tests/input/ExampleBackedEnum.php                     5       0
  tests/input/Exceptions.php                            1       0
  tests/input/forbidden-comments.php                    14      0
-@@ -54,9 +54,9 @@ tests/input/use-ordering.php                          1       0
+@@ -55,7 +55,7 @@ tests/input/use-ordering.php                          1       0
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 476 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
-+A TOTAL OF 469 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
+-A TOTAL OF 477 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
++A TOTAL OF 470 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
  ----------------------------------------------------------------------
 -PHPCBF CAN FIX 391 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 385 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
- 
- 
 diff --git a/tests/fixed/constants-var.php b/tests/fixed/constants-var.php
 index f10c235..d4268cb 100644
 --- a/tests/fixed/constants-var.php


### PR DESCRIPTION
Adds `SlevomatCodingStandard.Commenting.RequireOneDocComment` to prevent multiple PHPDoc blocks from being associated with the same symbol.

Raises the minimum `slevomat/coding-standard` version to `^8.24`, where the sniff was introduced.