### PR TITLE
Stop forcing early exit on a trailing single-instruction if

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -277,8 +277,12 @@
     </rule>
     <!-- Forbid fancy yoda conditions -->
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
-    <!-- Require usage of early exit -->
-    <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
+    <!-- Require usage of early exit where appropriate -->
+    <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit">
+        <properties>
+            <property name="ignoreTrailingIfWithOneInstruction" value="true"/>
+        </properties>
+    </rule>
     <!-- Require consistent spacing for jump statements -->
     <rule ref="SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing">
         <properties>

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -14,10 +14,10 @@ tests/input/ClassPropertySpacing.php                  2       0
 tests/input/concatenation_spacing.php                 49      0
 tests/input/constants-no-lsb.php                      2       0
 tests/input/constants-var.php                         13      0
-tests/input/ControlStructures.php                     28      0
+tests/input/ControlStructures.php                     27      0
 tests/input/doc-comment-spacing.php                   11      0
 tests/input/duplicate-assignment-variable.php         1       0
-tests/input/EarlyReturn.php                           7       0
+tests/input/EarlyReturn.php                           8       0
 tests/input/example-class.php                         48      0
 tests/input/ExampleBackedEnum.php                     5       0
 tests/input/Exceptions.php                            1       0

--- a/tests/fixed/ControlStructures.php
+++ b/tests/fixed/ControlStructures.php
@@ -17,11 +17,9 @@ class ControlStructures
     public function varAndIfNoSpaceBetween(): iterable
     {
         $var = 1;
-        if (self::VERSION !== 0) {
-            return;
+        if (self::VERSION === 0) {
+            yield 0;
         }
-
-        yield 0;
     }
 
     /** @return iterable<int> */

--- a/tests/fixed/EarlyReturn.php
+++ b/tests/fixed/EarlyReturn.php
@@ -41,4 +41,21 @@ class EarlyReturn
 
         return false === false;
     }
+
+    public function trailingIfWithOneInstruction(): void
+    {
+        if ($condition) {
+            echo 'one instruction is left alone';
+        }
+    }
+
+    public function trailingIfWithMultipleInstructions(): void
+    {
+        if (! $condition) {
+            return;
+        }
+
+        echo 'more than one instruction';
+        echo 'still requires an early exit';
+    }
 }

--- a/tests/input/EarlyReturn.php
+++ b/tests/input/EarlyReturn.php
@@ -49,4 +49,19 @@ class EarlyReturn
 
         return true;
     }
+
+    public function trailingIfWithOneInstruction(): void
+    {
+        if ($condition) {
+            echo 'one instruction is left alone';
+        }
+    }
+
+    public function trailingIfWithMultipleInstructions(): void
+    {
+        if ($condition) {
+            echo 'more than one instruction';
+            echo 'still requires an early exit';
+        }
+    }
 }

--- a/tests/php74-compatibility.patch
+++ b/tests/php74-compatibility.patch
@@ -8,14 +8,14 @@ index 8547171..f01ece0 100644
  tests/input/constants-no-lsb.php                      2       0
 -tests/input/constants-var.php                         13      0
 +tests/input/constants-var.php                         7       0
- tests/input/ControlStructures.php                     28      0
+ tests/input/ControlStructures.php                     27      0
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
--tests/input/EarlyReturn.php                           7       0
+-tests/input/EarlyReturn.php                           8       0
 -tests/input/example-class.php                         48      0
 -tests/input/ExampleBackedEnum.php                     5       0
 -tests/input/Exceptions.php                            1       0
-+tests/input/EarlyReturn.php                           6       0
++tests/input/EarlyReturn.php                           7       0
 +tests/input/example-class.php                         44      0
  tests/input/forbidden-comments.php                    14      0
  tests/input/forbidden-functions.php                   6       0

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -8,10 +8,10 @@ index 9b19b9e..760ee4a 100644
  tests/input/constants-no-lsb.php                      2       0
 -tests/input/constants-var.php                         13      0
 +tests/input/constants-var.php                         7       0
- tests/input/ControlStructures.php                     28      0
+ tests/input/ControlStructures.php                     27      0
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
- tests/input/EarlyReturn.php                           7       0
+ tests/input/EarlyReturn.php                           8       0
 -tests/input/example-class.php                         48      0
 -tests/input/ExampleBackedEnum.php                     5       0
 +tests/input/example-class.php                         47      0

--- a/tests/php81-compatibility.patch
+++ b/tests/php81-compatibility.patch
@@ -8,10 +8,10 @@ index 8547171..a7a42fa 100644
  tests/input/constants-no-lsb.php                      2       0
 -tests/input/constants-var.php                         13      0
 +tests/input/constants-var.php                         7       0
- tests/input/ControlStructures.php                     28      0
+ tests/input/ControlStructures.php                     27      0
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
- tests/input/EarlyReturn.php                           7       0
+ tests/input/EarlyReturn.php                           8       0
 -tests/input/example-class.php                         48      0
 +tests/input/example-class.php                         47      0
  tests/input/ExampleBackedEnum.php                     5       0

--- a/tests/php82-compatibility.patch
+++ b/tests/php82-compatibility.patch
@@ -8,10 +8,10 @@ index 8547171..a7a42fa 100644
  tests/input/constants-no-lsb.php                      2       0
 -tests/input/constants-var.php                         13      0
 +tests/input/constants-var.php                         7       0
- tests/input/ControlStructures.php                     28      0
+ tests/input/ControlStructures.php                     27      0
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
- tests/input/EarlyReturn.php                           7       0
+ tests/input/EarlyReturn.php                           8       0
 -tests/input/example-class.php                         48      0
 +tests/input/example-class.php                         47      0
  tests/input/ExampleBackedEnum.php                     5       0


### PR DESCRIPTION
Closes https://github.com/doctrine/coding-standard/issues/259.

I measured the effect on `doctrine/dbal` 4.5.x: with `ignoreTrailingIfWithOneInstruction`, 48 guard clauses can drop the inversion and go back to a plain trailing `if`. See doctrine/dbal#7411 for the effect of this change on DBAL 4.4.x.

The sniff has two other relaxations, and I'm leaving both off on purpose:

- `ignoreOneLineTrailingIf` only spares a one-line `if`. The option we're enabling already spares any single-statement `if`, which covers those too, so it adds nothing.
- `ignoreStandaloneIfInScope` doesn't seem to provide any reasonable benefits, so I'm leaving it as is.