### PR TITLE
feat(rules): enforce throws annotation order

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0.0",
-        "slevomat/coding-standard": "^8.26",
+        "slevomat/coding-standard": "^8.28",
         "squizlabs/php_codesniffer": "^4"
     },
     "config": {

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -258,6 +258,8 @@
     <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
     <!-- Require only one doc comment per symbol -->
     <rule ref="SlevomatCodingStandard.Commenting.RequireOneDocComment"/>
+    <!-- Require @throws annotations to be sorted alphabetically -->
+    <rule ref="SlevomatCodingStandard.Commenting.ThrowsAnnotationsOrder"/>
     <!-- Forbid assignments in conditions -->
     <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
     <!-- Require consistent spacing for block structures -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -16,7 +16,7 @@ tests/input/concatenation_spacing.php                 49      0
 tests/input/constants-no-lsb.php                      2       0
 tests/input/constants-var.php                         13      0
 tests/input/ControlStructures.php                     27      0
-tests/input/doc-comment-spacing.php                   11      0
+tests/input/doc-comment-spacing.php                   12      0
 tests/input/duplicate-assignment-variable.php         1       0
 tests/input/EarlyReturn.php                           8       0
 tests/input/example-class.php                         48      0
@@ -56,9 +56,9 @@ tests/input/use-ordering.php                          2       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     21      0
 ----------------------------------------------------------------------
-A TOTAL OF 481 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
+A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 395 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/doc-comment-spacing.php
+++ b/tests/fixed/doc-comment-spacing.php
@@ -47,7 +47,6 @@ class Test
      *
      * @link https://example.com
      * @see  other
-     * @uses other
      *
      * @ORM\Id
      * @ORM\Column
@@ -56,7 +55,6 @@ class Test
      * @PHPCR\Uuid
      * @PHPCR\Field
      *
-     * @param         int[] $foo
      * @param         int[] $bar
      * @psalm-param   array<string, int> $foo
      * @phpstan-param array<string, int> $foo
@@ -65,8 +63,8 @@ class Test
      * @psalm-return   array<string, int>
      * @phpstan-return array<string, int>
      *
-     * @throws FooException
      * @throws BarException
+     * @throws FooException
      */
     public function d(iterable $foo, iterable $bar): iterable
     {

--- a/tests/php74-compatibility.patch
+++ b/tests/php74-compatibility.patch
@@ -10,7 +10,7 @@ index 8547171..f01ece0 100644
 -tests/input/constants-var.php                         13      0
 +tests/input/constants-var.php                         7       0
  tests/input/ControlStructures.php                     27      0
- tests/input/doc-comment-spacing.php                   11      0
+ tests/input/doc-comment-spacing.php                   12      0
  tests/input/duplicate-assignment-variable.php         1       0
 -tests/input/EarlyReturn.php                           8       0
 -tests/input/example-class.php                         48      0
@@ -57,11 +57,11 @@ index 8547171..f01ece0 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 481 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
-+A TOTAL OF 433 ERRORS AND 2 WARNINGS WERE FOUND IN 48 FILES
+-A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 434 ERRORS AND 2 WARNINGS WERE FOUND IN 48 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 395 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 348 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 349 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/ClassKeywordOrder.php b/tests/fixed/ClassKeywordOrder.php
 index 29f6164..4b28352 100644

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -10,7 +10,7 @@ index 9b19b9e..760ee4a 100644
 -tests/input/constants-var.php                         13      0
 +tests/input/constants-var.php                         7       0
  tests/input/ControlStructures.php                     27      0
- tests/input/doc-comment-spacing.php                   11      0
+ tests/input/doc-comment-spacing.php                   12      0
  tests/input/duplicate-assignment-variable.php         1       0
  tests/input/EarlyReturn.php                           8       0
 -tests/input/example-class.php                         48      0
@@ -33,11 +33,11 @@ index 9b19b9e..760ee4a 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 481 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
-+A TOTAL OF 463 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
+-A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 464 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 395 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 378 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 379 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/ClassKeywordOrder.php b/tests/fixed/ClassKeywordOrder.php
 index 29f6164..4b28352 100644

--- a/tests/php81-compatibility.patch
+++ b/tests/php81-compatibility.patch
@@ -10,7 +10,7 @@ index 8547171..a7a42fa 100644
 -tests/input/constants-var.php                         13      0
 +tests/input/constants-var.php                         7       0
  tests/input/ControlStructures.php                     27      0
- tests/input/doc-comment-spacing.php                   11      0
+ tests/input/doc-comment-spacing.php                   12      0
  tests/input/duplicate-assignment-variable.php         1       0
  tests/input/EarlyReturn.php                           8       0
 -tests/input/example-class.php                         48      0
@@ -22,11 +22,11 @@ index 8547171..a7a42fa 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 481 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
-+A TOTAL OF 473 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
+-A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 474 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 395 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 388 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 389 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/ClassKeywordOrder.php b/tests/fixed/ClassKeywordOrder.php
 index 29f6164..4b28352 100644

--- a/tests/php82-compatibility.patch
+++ b/tests/php82-compatibility.patch
@@ -10,7 +10,7 @@ index 8547171..a7a42fa 100644
 -tests/input/constants-var.php                         13      0
 +tests/input/constants-var.php                         7       0
  tests/input/ControlStructures.php                     27      0
- tests/input/doc-comment-spacing.php                   11      0
+ tests/input/doc-comment-spacing.php                   12      0
  tests/input/duplicate-assignment-variable.php         1       0
  tests/input/EarlyReturn.php                           8       0
 -tests/input/example-class.php                         48      0
@@ -22,11 +22,11 @@ index 8547171..a7a42fa 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 481 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
-+A TOTAL OF 474 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
+-A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 475 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 395 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 389 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 390 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/constants-var.php b/tests/fixed/constants-var.php
 index f10c235..d4268cb 100644


### PR DESCRIPTION
Adds `SlevomatCodingStandard.Commenting.ThrowsAnnotationsOrder` to enforce alphabetical ordering of `@throws` annotations.

Raises the minimum `slevomat/coding-standard` version to `^8.28`, where the sniff was introduced.