### PR TITLE
feat(rules): format DNF types in doc comments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0.0",
-        "slevomat/coding-standard": "^8.28",
+        "slevomat/coding-standard": "^8.29",
         "squizlabs/php_codesniffer": "^4"
     },
     "config": {

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -503,6 +503,7 @@
             <property name="withSpacesInsideParentheses" value="no" />
             <property name="shortNullable" value="no" />
             <property name="nullPosition" value="last" />
+            <property name="enableForDocComments" value="true" />
         </properties>
     </rule>
     <!-- Forbid useless @var for constants -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -19,7 +19,7 @@ tests/input/ControlStructures.php                     27      0
 tests/input/doc-comment-spacing.php                   11      0
 tests/input/duplicate-assignment-variable.php         1       0
 tests/input/EarlyReturn.php                           8       0
-tests/input/example-class.php                         48      0
+tests/input/example-class.php                         49      0
 tests/input/ExampleBackedEnum.php                     5       0
 tests/input/Exceptions.php                            1       0
 tests/input/forbidden-comments.php                    14      0
@@ -50,15 +50,15 @@ tests/input/test-case.php                             8       0
 tests/input/trailing_comma_on_array.php               1       0
 tests/input/TrailingCommaOnFunctions.php              6       0
 tests/input/traits-uses.php                           12      0
-tests/input/type-hints.php                            9       0
+tests/input/type-hints.php                            12      0
 tests/input/UnusedVariables.php                       1       0
 tests/input/use-ordering.php                          2       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     21      0
 ----------------------------------------------------------------------
-A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
+A TOTAL OF 486 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 400 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/type-hints.php
+++ b/tests/fixed/type-hints.php
@@ -26,4 +26,9 @@ class TraversableTypeHints
 class UnionTypeHints
 {
     private int|string|null $x = 1;
+
+    /** @param array<int|string|null> $value */
+    public function set(array $value): void
+    {
+    }
 }

--- a/tests/input/type-hints.php
+++ b/tests/input/type-hints.php
@@ -27,4 +27,9 @@ class UnionTypeHints
 {
     /** @var null|int|string */
     private $x = 1;
+
+    /** @param array<null|int|string> $value */
+    public function set(array $value): void
+    {
+    }
 }

--- a/tests/php74-compatibility.patch
+++ b/tests/php74-compatibility.patch
@@ -13,7 +13,7 @@ index 8547171..f01ece0 100644
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
 -tests/input/EarlyReturn.php                           8       0
--tests/input/example-class.php                         48      0
+-tests/input/example-class.php                         49      0
 -tests/input/ExampleBackedEnum.php                     5       0
 -tests/input/Exceptions.php                            1       0
 +tests/input/EarlyReturn.php                           7       0
@@ -49,19 +49,19 @@ index 8547171..f01ece0 100644
 -tests/input/TrailingCommaOnFunctions.php              6       0
 +tests/input/TrailingCommaOnFunctions.php              2       0
  tests/input/traits-uses.php                           12      0
--tests/input/type-hints.php                            9       0
-+tests/input/type-hints.php                            8       0
+-tests/input/type-hints.php                            12      0
++tests/input/type-hints.php                            9       0
  tests/input/UnusedVariables.php                       1       0
  tests/input/use-ordering.php                          2       0
  tests/input/useless-semicolon.php                     2       0
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
-+A TOTAL OF 434 ERRORS AND 2 WARNINGS WERE FOUND IN 48 FILES
+-A TOTAL OF 486 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 435 ERRORS AND 2 WARNINGS WERE FOUND IN 48 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 349 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 400 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 350 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/ClassKeywordOrder.php b/tests/fixed/ClassKeywordOrder.php
 index 29f6164..4b28352 100644
@@ -409,14 +409,19 @@ diff --git a/tests/fixed/type-hints.php b/tests/fixed/type-hints.php
 index 5e26ed8..bfa6d4f 100644
 --- a/tests/fixed/type-hints.php
 +++ b/tests/fixed/type-hints.php
-@@ -25,5 +25,6 @@ class TraversableTypeHints
- 
+@@ -26,7 +26,8 @@
  class UnionTypeHints
  {
 -    private int|string|null $x = 1;
+-
+-    /** @param array<int|string|null> $value */
+-    public function set(array $value): void
 +    /** @var int|string|null */
 +    private $x = 1;
- }
++
++    /** @param array<int|string|null> $value */
++    public function set(array $value): void
+     {
 diff --git a/tests/input/ControlStructures.php b/tests/input/ControlStructures.php
 index 7c20d0e..a0e0b2e 100644
 --- a/tests/input/ControlStructures.php

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -13,9 +13,9 @@ index 9b19b9e..760ee4a 100644
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
  tests/input/EarlyReturn.php                           8       0
--tests/input/example-class.php                         48      0
+-tests/input/example-class.php                         49      0
 -tests/input/ExampleBackedEnum.php                     5       0
-+tests/input/example-class.php                         47      0
++tests/input/example-class.php                         48      0
  tests/input/Exceptions.php                            1       0
  tests/input/forbidden-comments.php                    14      0
  tests/input/forbidden-functions.php                   6       0
@@ -33,11 +33,11 @@ index 9b19b9e..760ee4a 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
-+A TOTAL OF 464 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
+-A TOTAL OF 486 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 468 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 379 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 400 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 383 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/ClassKeywordOrder.php b/tests/fixed/ClassKeywordOrder.php
 index 29f6164..4b28352 100644

--- a/tests/php81-compatibility.patch
+++ b/tests/php81-compatibility.patch
@@ -13,8 +13,8 @@ index 8547171..a7a42fa 100644
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
  tests/input/EarlyReturn.php                           8       0
--tests/input/example-class.php                         48      0
-+tests/input/example-class.php                         47      0
+-tests/input/example-class.php                         49      0
++tests/input/example-class.php                         48      0
  tests/input/ExampleBackedEnum.php                     5       0
  tests/input/Exceptions.php                            1       0
  tests/input/forbidden-comments.php                    14      0
@@ -22,11 +22,11 @@ index 8547171..a7a42fa 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
-+A TOTAL OF 474 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
+-A TOTAL OF 486 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 478 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 389 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 400 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 393 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/ClassKeywordOrder.php b/tests/fixed/ClassKeywordOrder.php
 index 29f6164..4b28352 100644

--- a/tests/php82-compatibility.patch
+++ b/tests/php82-compatibility.patch
@@ -13,8 +13,8 @@ index 8547171..a7a42fa 100644
  tests/input/doc-comment-spacing.php                   11      0
  tests/input/duplicate-assignment-variable.php         1       0
  tests/input/EarlyReturn.php                           8       0
--tests/input/example-class.php                         48      0
-+tests/input/example-class.php                         47      0
+-tests/input/example-class.php                         49      0
++tests/input/example-class.php                         48      0
  tests/input/ExampleBackedEnum.php                     5       0
  tests/input/Exceptions.php                            1       0
  tests/input/forbidden-comments.php                    14      0
@@ -22,11 +22,11 @@ index 8547171..a7a42fa 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 482 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
-+A TOTAL OF 475 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
+-A TOTAL OF 486 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 479 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 396 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 390 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 400 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 394 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/constants-var.php b/tests/fixed/constants-var.php
 index f10c235..d4268cb 100644


### PR DESCRIPTION
Enables `SlevomatCodingStandard.TypeHints.DNFTypeHintFormat` `enableForDocComments` so DNF type formatting is also enforced in PHPDoc annotations.

Raises the minimum `slevomat/coding-standard` version to `^8.29`, where the option was introduced.