### PR TITLE
feat(rules): enforce catch exception order

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -313,6 +313,8 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn"/>
     <!-- Forbid usage of boolean-only ternary operator usage (e.g. $foo ? true : false) -->
     <rule ref="SlevomatCodingStandard.ControlStructures.UselessTernaryOperator"/>
+    <!-- Require catch exception types to be sorted alphabetically -->
+    <rule ref="SlevomatCodingStandard.Exceptions.CatchExceptionsOrder"/>
     <!-- Forbid useless unreachable catch blocks -->
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
     <!-- Require using Throwable instead of Exception -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -21,7 +21,7 @@ tests/input/duplicate-assignment-variable.php         1       0
 tests/input/EarlyReturn.php                           8       0
 tests/input/example-class.php                         49      0
 tests/input/ExampleBackedEnum.php                     5       0
-tests/input/Exceptions.php                            1       0
+tests/input/Exceptions.php                            2       0
 tests/input/forbidden-comments.php                    14      0
 tests/input/forbidden-functions.php                   6       0
 tests/input/inline_type_hint_assertions.php           10      0
@@ -56,9 +56,9 @@ tests/input/use-ordering.php                          2       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     21      0
 ----------------------------------------------------------------------
-A TOTAL OF 486 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
+A TOTAL OF 487 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 400 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 401 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/Exceptions.php
+++ b/tests/fixed/Exceptions.php
@@ -5,9 +5,16 @@ declare(strict_types=1);
 namespace Exceptions;
 
 use Exception;
+use LogicException;
+use RuntimeException;
 use Throwable;
 
 try {
     throw new Exception();
 } catch (Throwable) {
+}
+
+try {
+    throw new LogicException();
+} catch (LogicException | RuntimeException) {
 }

--- a/tests/input/Exceptions.php
+++ b/tests/input/Exceptions.php
@@ -5,9 +5,16 @@ declare(strict_types=1);
 namespace Exceptions;
 
 use Exception;
+use LogicException;
+use RuntimeException;
 use Throwable;
 
 try {
     throw new Exception();
 } catch (Throwable $throwable) {
+}
+
+try {
+    throw new LogicException();
+} catch (RuntimeException | LogicException) {
 }

--- a/tests/php74-compatibility.patch
+++ b/tests/php74-compatibility.patch
@@ -15,7 +15,7 @@ index 8547171..f01ece0 100644
 -tests/input/EarlyReturn.php                           8       0
 -tests/input/example-class.php                         49      0
 -tests/input/ExampleBackedEnum.php                     5       0
--tests/input/Exceptions.php                            1       0
+-tests/input/Exceptions.php                            2       0
 +tests/input/EarlyReturn.php                           7       0
 +tests/input/example-class.php                         44      0
  tests/input/forbidden-comments.php                    14      0
@@ -57,10 +57,10 @@ index 8547171..f01ece0 100644
 -tests/input/UselessConditions.php                     21      0
 +tests/input/UselessConditions.php                     20      0
  ----------------------------------------------------------------------
--A TOTAL OF 486 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
+-A TOTAL OF 487 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
 +A TOTAL OF 435 ERRORS AND 2 WARNINGS WERE FOUND IN 48 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 400 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 401 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 +PHPCBF CAN FIX 350 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/ClassKeywordOrder.php b/tests/fixed/ClassKeywordOrder.php
@@ -142,20 +142,27 @@ index fd701eb..fe54eb9 100644
 -    case BAM = 1234;
 -}
 diff --git a/tests/fixed/Exceptions.php b/tests/fixed/Exceptions.php
-index db7408b..9b146c6 100644
+index eba1df2..9b146c6 100644
 --- a/tests/fixed/Exceptions.php
 +++ b/tests/fixed/Exceptions.php
-@@ -3,11 +3,3 @@
+@@ -3,18 +3,3 @@
  declare(strict_types=1);
  
  namespace Exceptions;
 -
 -use Exception;
+-use LogicException;
+-use RuntimeException;
 -use Throwable;
 -
 -try {
 -    throw new Exception();
 -} catch (Throwable) {
+-}
+-
+-try {
+-    throw new LogicException();
+-} catch (LogicException | RuntimeException) {
 -}
 diff --git a/tests/fixed/NamingCamelCase.php b/tests/fixed/NamingCamelCase.php
 index 5493471..57d9f2b 100644
@@ -466,20 +473,27 @@ index 3b09f47..fe54eb9 100644
 -    case BAM = 1234;
 -}
 diff --git a/tests/input/Exceptions.php b/tests/input/Exceptions.php
-index 3aaa30f..9b146c6 100644
+index 048b7fb..9b146c6 100644
 --- a/tests/input/Exceptions.php
 +++ b/tests/input/Exceptions.php
-@@ -3,11 +3,3 @@
+@@ -3,18 +3,3 @@
  declare(strict_types=1);
  
  namespace Exceptions;
 -
 -use Exception;
+-use LogicException;
+-use RuntimeException;
 -use Throwable;
 -
 -try {
 -    throw new Exception();
 -} catch (Throwable $throwable) {
+-}
+-
+-try {
+-    throw new LogicException();
+-} catch (RuntimeException | LogicException) {
 -}
 diff --git a/tests/input/PropertyDeclaration.php b/tests/input/PropertyDeclaration.php
 index acdc445..0891e12 100644

--- a/tests/php80-compatibility.patch
+++ b/tests/php80-compatibility.patch
@@ -16,7 +16,7 @@ index 9b19b9e..760ee4a 100644
 -tests/input/example-class.php                         49      0
 -tests/input/ExampleBackedEnum.php                     5       0
 +tests/input/example-class.php                         48      0
- tests/input/Exceptions.php                            1       0
+ tests/input/Exceptions.php                            2       0
  tests/input/forbidden-comments.php                    14      0
  tests/input/forbidden-functions.php                   6       0
 @@ -34,8 +33,8 @@ tests/input/null_coalesce_equal_operator.php          5       0
@@ -33,11 +33,11 @@ index 9b19b9e..760ee4a 100644
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 486 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
-+A TOTAL OF 468 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
+-A TOTAL OF 487 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 469 ERRORS AND 2 WARNINGS WERE FOUND IN 50 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 400 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 383 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 401 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 384 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/ClassKeywordOrder.php b/tests/fixed/ClassKeywordOrder.php
 index 29f6164..4b28352 100644

--- a/tests/php81-compatibility.patch
+++ b/tests/php81-compatibility.patch
@@ -16,17 +16,17 @@ index 8547171..a7a42fa 100644
 -tests/input/example-class.php                         49      0
 +tests/input/example-class.php                         48      0
  tests/input/ExampleBackedEnum.php                     5       0
- tests/input/Exceptions.php                            1       0
+ tests/input/Exceptions.php                            2       0
  tests/input/forbidden-comments.php                    14      0
 @@ -55,7 +54,7 @@ tests/input/use-ordering.php                          1       0
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 486 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
-+A TOTAL OF 478 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
+-A TOTAL OF 487 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 479 ERRORS AND 2 WARNINGS WERE FOUND IN 51 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 400 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 393 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 401 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 394 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/ClassKeywordOrder.php b/tests/fixed/ClassKeywordOrder.php
 index 29f6164..4b28352 100644

--- a/tests/php82-compatibility.patch
+++ b/tests/php82-compatibility.patch
@@ -16,17 +16,17 @@ index 8547171..a7a42fa 100644
 -tests/input/example-class.php                         49      0
 +tests/input/example-class.php                         48      0
  tests/input/ExampleBackedEnum.php                     5       0
- tests/input/Exceptions.php                            1       0
+ tests/input/Exceptions.php                            2       0
  tests/input/forbidden-comments.php                    14      0
 @@ -55,7 +55,7 @@ tests/input/use-ordering.php                          2       0
  tests/input/useless-semicolon.php                     2       0
  tests/input/UselessConditions.php                     21      0
  ----------------------------------------------------------------------
--A TOTAL OF 486 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
-+A TOTAL OF 479 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
+-A TOTAL OF 487 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
++A TOTAL OF 480 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
  ----------------------------------------------------------------------
--PHPCBF CAN FIX 400 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
-+PHPCBF CAN FIX 394 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+-PHPCBF CAN FIX 401 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
++PHPCBF CAN FIX 395 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
  ----------------------------------------------------------------------
 diff --git a/tests/fixed/constants-var.php b/tests/fixed/constants-var.php
 index f10c235..d4268cb 100644


### PR DESCRIPTION
Adds the Slevomat catch exception order rule and updates the fixtures/report expectations.

This is separate from #378: that PR was closed because we wanted to keep control over `@throws` annotation order. Catch exception order is a different case because it affects caught exception type ordering in code, not docblock annotation ordering.