### PR TITLE
Slevomat ReturnTypeHintSpacing: remove default spacesCountBeforeColon configuration

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -460,11 +460,7 @@
     <!-- Require one space between typehint and variable, require no space between nullability sign and typehint -->
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
     <!-- Require space around colon in return types -->
-    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing">
-        <properties>
-            <property name="spacesCountBeforeColon" value="0"/>
-        </properties>
-    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
     <!-- Require types to be written as natively if possible;
          require iterable types to specify phpDoc with their content;
          forbid useless/duplicated information in phpDoc -->


### PR DESCRIPTION
Resurrects #201 against `15.0.x`.

This was changed to zero in #163, but this is the default, so there is no need for the override:
https://github.com/slevomat/coding-standard/blob/c4e287879af90a2f56b1b516deaba707858c9a24/SlevomatCodingStandard/Sniffs/TypeHints/ReturnTypeHintSpacingSniff.php#L35

The Slevomat maintainer also said this default will not change in the future.

Closes #201