### PR TITLE
feat(rules): disallow arrow function return type hints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0.0",
-        "slevomat/coding-standard": "^8.29",
+        "slevomat/coding-standard": "^8.31",
         "squizlabs/php_codesniffer": "^4"
     },
     "config": {

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -327,6 +327,7 @@
             <property name="spacesCountAfterKeyword" value="1"/>
             <property name="spacesCountBeforeArrow" value="1"/>
             <property name="spacesCountAfterArrow" value="1"/>
+            <property name="disallowReturnTypeHint" value="true"/>
         </properties>
     </rule>
     <!-- Disallow trailing commas in single line function calls -->

--- a/tests/expected_report.txt
+++ b/tests/expected_report.txt
@@ -5,7 +5,7 @@ FILE                                                  ERRORS  WARNINGS
 ----------------------------------------------------------------------
 tests/input/annotation-name.php                       8       0
 tests/input/array_indentation.php                     10      0
-tests/input/arrow-functions-format.php                12      0
+tests/input/arrow-functions-format.php                16      0
 tests/input/assignment-operators.php                  4       0
 tests/input/attributes.php                            15      0
 tests/input/binary_operators.php                      9       0
@@ -56,9 +56,9 @@ tests/input/use-ordering.php                          2       0
 tests/input/useless-semicolon.php                     2       0
 tests/input/UselessConditions.php                     21      0
 ----------------------------------------------------------------------
-A TOTAL OF 487 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
+A TOTAL OF 491 ERRORS AND 2 WARNINGS WERE FOUND IN 52 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 401 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 405 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/tests/fixed/arrow-functions-format.php
+++ b/tests/fixed/arrow-functions-format.php
@@ -6,9 +6,9 @@ $missingStatic = static fn ($a, $b) => $a + $b;
 
 $uselessParentheses = static fn ($x) => $x + $y;
 
-$withReturnType = static fn (): int => 1 + 2;
+$withReturnType = static fn () => 1 + 2;
 
-$withTypesInArguments = static fn (int $a, int $b): int => $a + $b;
+$withTypesInArguments = static fn (int $a, int $b) => $a + $b;
 
 $spacing = static fn (int $x) => $x * 2;
 
@@ -18,10 +18,10 @@ $returningObject = static fn () => new stdClass();
 
 $multiLineArrowFunctions = Collection::from([1, 2])
     ->map(
-        static fn (int $v): int => $v * 2,
+        static fn (int $v) => $v * 2,
     )
     ->reduce(
-        static fn (int $tmp, int $v): int => $tmp + $v,
+        static fn (int $tmp, int $v) => $tmp + $v,
     );
 
 $thisIsNotAnArrowFunction = [$this->fn => 'value'];


### PR DESCRIPTION
Enable Slevomat's `disallowReturnTypeHint` option for arrow functions.

Require Slevomat Coding Standard 8.31, which introduced the option, and update the arrow-function fixtures.