### PR TITLE
Refine rules

### DIFF
--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -104,6 +104,8 @@
     <rule ref="Generic.PHP.SAPIUsage"/>
     <!-- Require there be no space between increment/decrement operator and its operand -->
     <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
+    <!-- Require space after language constructs -->
+    <rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
     <!-- Forbid comments starting with # -->
     <rule ref="PEAR.Commenting.InlineComment"/>
     <!-- Disallow else if in favor of elseif -->
@@ -631,8 +633,6 @@
             <property name="spacingAfterLast" value="0"/>
         </properties>
     </rule>
-    <!-- Require space after language constructs -->
-    <rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
     <!-- Require space around logical operators -->
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
     <!-- Forbid spaces around `->` operator -->

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -619,8 +619,6 @@
     <rule ref="Squiz.Strings.DoubleQuoteUsage"/>
     <!-- Forbid braces around string in `echo` -->
     <rule ref="Squiz.Strings.EchoedStrings"/>
-    <!-- Forbid spaces in type casts -->
-    <rule ref="Squiz.WhiteSpace.CastSpacing"/>
     <!-- Forbid blank line after function opening brace -->
     <rule ref="Squiz.WhiteSpace.FunctionOpeningBraceSpace"/>
     <!-- Require 1 line before and after function, except at the top and bottom -->

--- a/lib/Doctrine/ruleset.xml
+++ b/lib/Doctrine/ruleset.xml
@@ -102,6 +102,8 @@
     <rule ref="Generic.PHP.LowerCaseType"/>
     <!-- Forbid `php_sapi_name()` function -->
     <rule ref="Generic.PHP.SAPIUsage"/>
+    <!-- Require there be no space between increment/decrement operator and its operand -->
+    <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
     <!-- Forbid comments starting with # -->
     <rule ref="PEAR.Commenting.InlineComment"/>
     <!-- Disallow else if in favor of elseif -->
@@ -629,8 +631,6 @@
             <property name="spacingAfterLast" value="0"/>
         </properties>
     </rule>
-    <!-- Require there be no space between increment/decrement operator and its operand -->
-    <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
     <!-- Require space after language constructs -->
     <rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
     <!-- Require space around logical operators -->


### PR DESCRIPTION
Continues #222, while retaining `PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace` as requested in its review.

`Squiz.WhiteSpace.CastSpacing` is already included in PSR-12.

Also moves `Generic.WhiteSpace.IncrementDecrementSpacing` and `Generic.WhiteSpace.LanguageConstructSpacing` into alphabetical order.